### PR TITLE
refactor: update to nativescript-dev-webpack 0.14.0

### DIFF
--- a/src/add-ns/index.ts
+++ b/src/add-ns/index.ts
@@ -157,26 +157,15 @@ const installNpmModules = () => (_tree: Tree, context: SchematicContext) => {
       'tns-core-modules': '~4.1.0'
     },
     devDependencies: {
-      'nativescript-dev-typescript': '~0.7.0',
-      'nativescript-dev-webpack': '^0.13.0',
-      '@angular/cli': '6.1.0-beta.0',
-
-      '@angular-devkit/build-angular': '0.7.0-beta.2',
-      '@angular-devkit/core': '0.7.0-beta.2',
-
-      'typescript': '2.7.2'
+      'nativescript-dev-webpack': '^0.14.0'
     }
   }
 
   const options: NpmInstallOptions = {
     json: JSON.stringify(dependeciesToAdd)
   }
-  const taskId = context.addTask(new RunSchematicTask('@nativescript/schematics', 'npm-install', options));
 
-  // run for the second time, to npm install modules added by nativescript-dev-webpack
-  // npmInstallTaskId = context.addTask(new RunSchematicTask('@nativescript/schematics', 'npm-install', {}), [taskId]);
-  context.addTask(new RunSchematicTask('@nativescript/schematics', 'npm-install', {}), [taskId]);
-
+  context.addTask(new RunSchematicTask('@nativescript/schematics', 'npm-install', options));
 }
 
 const addWebpackConfig = () => (tree:Tree) => {

--- a/src/ng-new/application/_files/package.json
+++ b/src/ng-new/application/_files/package.json
@@ -30,21 +30,9 @@
     "babel-traverse": "6.26.0",
     "babel-types": "6.26.0",
     "babylon": "6.18.0",
-    "clean-webpack-plugin": "~0.1.19",
-    "copy-webpack-plugin": "~4.5.1",
-    "css-loader": "~0.28.11",
-    "extract-text-webpack-plugin": "~3.0.2",
     "lazy": "1.0.11",
-    "nativescript-dev-webpack": "^0.13.0",
+    "nativescript-dev-webpack": "^0.14.0",
     "nativescript-dev-typescript": "~0.7.0",
-    "nativescript-worker-loader": "~0.9.0",
-    "raw-loader": "~0.5.1",
-    "resolve-url-loader": "~2.3.0",
-    "typescript": "~2.7.2",
-    "uglifyjs-webpack-plugin": "~1.2.5",
-    "webpack": "~4.6.0",
-    "webpack-bundle-analyzer": "~2.13.0",
-    "webpack-cli": "~2.1.3",
-    "webpack-sources": "~1.1.0"
+    "typescript": "~2.7.2"
   }
 }

--- a/src/ng-new/shared/_files/package.json
+++ b/src/ng-new/shared/_files/package.json
@@ -34,10 +34,8 @@
   "devDependencies": {
     "@angular/compiler-cli": "^6.0.3",
     "@angular-devkit/build-angular": "0.7.0-beta.0",
-    "@angular-devkit/core": "0.7.0-beta.0",
     "typescript": "2.7.2",
     "@angular/cli": "6.1.0-beta.0",
-    "@ngtools/webpack": "6.1.0-beta.0",
     "@angular/language-service": "^6.0.3",
     "@types/jasmine": "~2.8.6",
     "@types/jasminewd2": "~2.0.3",
@@ -54,18 +52,6 @@
     "ts-node": "~5.0.1",
     "tslint": "~5.9.1",
     "nativescript-dev-typescript": "~0.7.0",
-    "nativescript-dev-webpack": "^0.13.0",
-    "webpack": "~4.6.0",
-    "webpack-cli": "~2.1.3",
-    "webpack-bundle-analyzer": "~2.13.0",
-    "webpack-sources": "~1.1.0",
-    "clean-webpack-plugin": "~0.1.19",
-    "copy-webpack-plugin": "~4.5.1",
-    "raw-loader": "~0.5.1",
-    "css-loader": "~0.28.11",
-    "nativescript-worker-loader": "~0.9.0",
-    "extract-text-webpack-plugin": "~3.0.2",
-    "uglifyjs-webpack-plugin": "~1.2.5",
-    "resolve-url-loader": "~2.3.0"
+    "nativescript-dev-webpack": "^0.14.0"
   }
 }


### PR DESCRIPTION
The webpack packages required for the {N} build are now dependencies of the nativescript-dev-webpack plugin. We can now remove them from the project's package.json and stop running `npm i` twice when adding `nativescript-dev-webpack` to the project.