### PR TITLE
fix: module.id issue in code sharing projects

### DIFF
--- a/src/add-ns/_ns-files/__sourceDir__/app/__entryComponentName@dasherize__.component__nsext__.ts
+++ b/src/add-ns/_ns-files/__sourceDir__/app/__entryComponentName@dasherize__.component__nsext__.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: '<%= indexAppRootTag %>',
-  moduleId: module.id,
   templateUrl: '<%= entryComponentImportPath %>.html',
 })
 

--- a/src/add-ns/_ns-files/__sourceDir__/app/barcelona/player-detail/player-detail.component.ts
+++ b/src/add-ns/_ns-files/__sourceDir__/app/barcelona/player-detail/player-detail.component.ts
@@ -6,7 +6,6 @@ import { PlayerService } from '../player.service';
 
 @Component({
   selector: 'ns-details',
-  moduleId: module.id,
   templateUrl: './player-detail.component.html',
 })
 export class PlayerDetailComponent implements OnInit {

--- a/src/add-ns/_ns-files/__sourceDir__/app/barcelona/players/players.component.ts
+++ b/src/add-ns/_ns-files/__sourceDir__/app/barcelona/players/players.component.ts
@@ -5,7 +5,6 @@ import { PlayerService } from '../player.service';
 
 @Component({
   selector: 'ns-players',
-  moduleId: module.id,
   templateUrl: './players.component.html',
 })
 export class PlayersComponent implements OnInit {

--- a/src/generate/component/index.ts
+++ b/src/generate/component/index.ts
@@ -77,7 +77,7 @@ export default function (options: ComponentOptions): Rule {
     },
 
     (tree: Tree) => {
-      if (platformUse.useNs) {
+      if (platformUse.nsOnly) {
         insertModuleId(tree, componentInfo.classPath);
       }
     },

--- a/src/migrate-component/index.ts
+++ b/src/migrate-component/index.ts
@@ -18,7 +18,6 @@ import { dirname, basename } from 'path';
 import { Schema as MigrateComponentSchema } from './schema';
 
 import { getSourceFile, addExtension, findRelativeImportPath } from '../utils';
-import { insertModuleId } from '../ast-utils';
 import { ComponentInfo, parseComponentInfo } from './component-info-utils';
 import { getNsConfigExtension, Extensions } from '../generate/utils';
 
@@ -37,8 +36,6 @@ export default function(options: MigrateComponentSchema): Rule {
     (tree: Tree, context: SchematicContext) => {
       componentInfo = parseComponentInfo(options)(tree, context);
     },
-    (tree: Tree) => 
-      updateComponentClass(tree, componentInfo),
     
     (tree: Tree, context: SchematicContext) =>
       addNsFiles(componentInfo, options)(tree, context),
@@ -47,9 +44,6 @@ export default function(options: MigrateComponentSchema): Rule {
       addComponentToNsModuleProviders(componentInfo, options)(tree)
   ]);
 }
-
-const updateComponentClass = (tree: Tree, componentInfo: ComponentInfo) => 
-  insertModuleId(tree, componentInfo.componentPath)
 
 const addNsFiles = (componentInfo: ComponentInfo, options: MigrateComponentSchema) => (tree: Tree, context: SchematicContext) => {
   context.logger.info('Adding {N} files');

--- a/src/ng-new/shared/_files/__sourcedir__/app/app.component.ts
+++ b/src/ng-new/shared/_files/__sourcedir__/app/app.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: '<%= prefix %>-root',
-  moduleId: module.id,
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.<%= style %>']
 })

--- a/src/ng-new/shared/_files/__sourcedir__/app/barcelona/player-detail/player-detail.component.ts
+++ b/src/ng-new/shared/_files/__sourcedir__/app/barcelona/player-detail/player-detail.component.ts
@@ -6,7 +6,6 @@ import { PlayerService } from '../player.service';
 
 @Component({
   selector: '<%= prefix %>-details',
-  moduleId: module.id,
   templateUrl: './player-detail.component.html',
 })
 export class PlayerDetailComponent implements OnInit {

--- a/src/ng-new/shared/_files/__sourcedir__/app/barcelona/players/players.component.ts
+++ b/src/ng-new/shared/_files/__sourcedir__/app/barcelona/players/players.component.ts
@@ -5,7 +5,6 @@ import { PlayerService } from '../player.service';
 
 @Component({
   selector: '<%= prefix %>-players',
-  moduleId: module.id,
   templateUrl: './players.component.html',
 })
 export class PlayersComponent implements OnInit {


### PR DESCRIPTION
This PR removes `moduleId: module.id` from all components generated by code sharing schematics.
Also, `ng g c` will only add `moduleId: module.id` for `{N} Only` projects, but it won't do it inside code sharing projects

fixes #40