### PR TITLE
chore(ng-new): add hooks and platforms to shared .gitignore

### DIFF
--- a/src/ng-new/shared/_files/__dot__gitignore
+++ b/src/ng-new/shared/_files/__dot__gitignore
@@ -4,10 +4,13 @@
 /dist
 /tmp
 /out-tsc
-/platforms
 
 # dependencies
 /node_modules
+
+# NativeScript
+/hooks
+/platforms
 
 # IDEs and editors
 /.idea
@@ -29,7 +32,6 @@
 /.sass-cache
 /connect.lock
 /coverage
-/hooks
 /libpeerconnection.log
 npm-debug.log
 yarn-error.log

--- a/src/ng-new/shared/_files/__dot__gitignore
+++ b/src/ng-new/shared/_files/__dot__gitignore
@@ -4,6 +4,7 @@
 /dist
 /tmp
 /out-tsc
+/platforms
 
 # dependencies
 /node_modules
@@ -28,6 +29,7 @@
 /.sass-cache
 /connect.lock
 /coverage
+/hooks
 /libpeerconnection.log
 npm-debug.log
 yarn-error.log


### PR DESCRIPTION
Add NativeScript `hooks` and `platforms` folders to the default `.gitignore` of a new shared project.