### PR TITLE
test: do not test node_modules specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "watch": "tsc -w -p tsconfig.json",
-    "test": "npm run build && jasmine **/*_spec.js",
+    "test": "npm run build && jasmine src/**/*_spec.js",
     "prepare": "npm run build",
     "debug": "node --debug-brk $(which ng) g command",
     "debug-v8": "node --inspect-brk $(which ng) g command",


### PR DESCRIPTION
The `test` script fails because it tries to execute `needle` specs from `node_modules`.

```
Error: ENOENT: no such file or directory, open '/Users/nsbuilduser/workspace/nativescript-schematics/node_modules/fsevents/node_modules/needle/test/keys/ssl.cert'
    at Object.fs.openSync (fs.js:646:18)
    at Object.fs.readFileSync (fs.js:551:33)
    at Object.<anonymous> (/Users/nsbuilduser/workspace/nativescript-schematics/node_modules/fsevents/node_modules/needle/test/helpers.js:9:13)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @nativescript/schematics@0.2.4 test: `npm run build && jasmine **/*_spec.js`
```

https://github.com/angular/devkit/issues/860