### PR TITLE
Extend module and migrate-module unit tests

### DIFF
--- a/src/ast-utils.ts
+++ b/src/ast-utils.ts
@@ -641,6 +641,7 @@ export const insertModuleId = (tree: Tree, component: string) => {
     recorder.insertRight(change.pos, change.toAdd)
   );
   tree.commitUpdate(recorder);
+
 };
 
 export const updateNodeText = (tree: Tree, node: ts.Node, newText: string) => {
@@ -648,7 +649,7 @@ export const updateNodeText = (tree: Tree, node: ts.Node, newText: string) => {
   recorder.remove(node.getStart(), node.getText().length);
   recorder.insertLeft(node.getStart(), newText);
   tree.commitUpdate(recorder);
-}
+};
 
 export const replaceTextInNode = (tree: Tree, node: ts.Node, oldText: string, newText: string) => {
   const index = node.getStart() + node.getText().indexOf(oldText);

--- a/src/generate/module/index.ts
+++ b/src/generate/module/index.ts
@@ -115,14 +115,15 @@ export default function (options: ModuleOptions): Rule {
       }
     },
 
-    (tree: Tree) => shouldCreateCommonFile(platformUse) ?
+    (tree: Tree) => shouldCreateCommonFile(platformUse, options.common) ?
       addCommonFile(moduleInfo) : tree
   ]));
 };
 
-const shouldCreateCommonFile = (platformUse: PlatformUse) =>
+const shouldCreateCommonFile = (platformUse: PlatformUse, useCommon?: boolean) =>
+  !!useCommon || // the common flag is raised or
   !platformUse.nsOnly && // it's a shared project
-  platformUse.useWeb && platformUse.useNs; // and we want a shared module
+  platformUse.useWeb && platformUse.useNs; // and we generate a shared module
 
 const addCommonFile = (moduleInfo: ModuleInfo) => {
   return mergeWith(

--- a/src/generate/module/index.ts
+++ b/src/generate/module/index.ts
@@ -64,7 +64,8 @@ export default function (options: ModuleOptions): Rule {
       const {
         moduleName,
         routingName
-      } = getParsedName(options)
+      } = getParsedName(options);
+
       return ![moduleName, routingName].some(modName => fileName.endsWith(modName));
     }),
 
@@ -114,10 +115,14 @@ export default function (options: ModuleOptions): Rule {
       }
     },
 
-    (tree: Tree) => (platformUse.nsOnly) ?
-      tree : addCommonFile(moduleInfo)
+    (tree: Tree) => shouldCreateCommonFile(platformUse) ?
+      addCommonFile(moduleInfo) : tree
   ]));
 };
+
+const shouldCreateCommonFile = (platformUse: PlatformUse) =>
+  !platformUse.nsOnly && // it's a shared project
+  platformUse.useWeb && platformUse.useNs; // and we want a shared module
 
 const addCommonFile = (moduleInfo: ModuleInfo) => {
   return mergeWith(

--- a/src/generate/module/index_spec.ts
+++ b/src/generate/module/index_spec.ts
@@ -24,6 +24,7 @@ describe('Module Schematic', () => {
   const noExtensionModulePath = getModulePath('');
   const nsModulePath = getModulePath(DEFAULT_SHARED_EXTENSIONS.ns);
   const webModulePath = getModulePath(DEFAULT_SHARED_EXTENSIONS.web);
+  const commonFilePath = `/src/app/${name}/${name}.common.ts`;
 
   const getRoutingModulePath = (extension: string) => `/src/app/${name}/${name}-routing.module${extension}.ts`;
   const noExtensionRoutingModulePath = getRoutingModulePath('');
@@ -49,9 +50,12 @@ describe('Module Schematic', () => {
         expect(getFileContent(tree, noExtensionModulePath)).toContain(`class ${moduleClassName}`);
       });
 
-
       it('should not create files with .tns extension', () => {
         expect(tree.exists(nsModulePath)).toBeFalsy();
+      });
+
+      it('should not create a common file', () => {
+        expect(tree.exists(commonFilePath)).toBeFalsy();
       });
 
       it('should not have CommonModule imported', () => {
@@ -151,6 +155,13 @@ describe('Module Schematic', () => {
         expect(tree.exists(nsModulePath)).toBeFalsy();
       });
 
+      it('should not create a common file', () => {
+        const options = { ...webOnlyOptions };
+        const tree = schematicRunner.runSchematic('module', options, appTree);
+
+        expect(tree.exists(commonFilePath)).toBeFalsy();
+      });
+
       it('should respect passed extension', () => {
         const customExtension = '.web';
         const options = { ...webOnlyOptions, webExtension: customExtension, routing: true };
@@ -176,6 +187,13 @@ describe('Module Schematic', () => {
         const tree = schematicRunner.runSchematic('module', options, appTree);
         expect(tree.exists(nsModulePath)).toBeTruthy();
         expect(tree.exists(webModulePath)).toBeTruthy();
+      });
+
+      it('should not create a common file', () => {
+        const options = { ...nsWebOptions };
+        const tree = schematicRunner.runSchematic('module', options, appTree);
+
+        expect(tree.exists(commonFilePath)).toBeTruthy();
       });
 
       it('should create both routing modules when routing flag is passed', () => {

--- a/src/generate/module/index_spec.ts
+++ b/src/generate/module/index_spec.ts
@@ -133,7 +133,40 @@ describe('Module Schematic', () => {
     describe('executing ns-only schematic', () => {
       const nsOnlyOptions = { ...defaultOptions, nativescript: true, web: false };
 
-      // TODO: add tests here
+      it('should create ns module file', () => {
+        const options = { ...nsOnlyOptions };
+        const tree = schematicRunner.runSchematic('module', options, appTree);
+
+        expect(tree.files.indexOf(nsModulePath)).toBeGreaterThanOrEqual(0);
+        expect(getFileContent(tree, nsModulePath)).toContain('CommonModule');
+        expect(getFileContent(tree, nsModulePath)).toContain(`class ${moduleClassName}`);
+      });
+
+      it('should not create web module file', () => {
+        const options = { ...nsOnlyOptions };
+        const tree = schematicRunner.runSchematic('module', options, appTree);
+
+        expect(tree.exists(webModulePath)).toBeFalsy();
+      });
+
+      it('should not create a common file', () => {
+        const options = { ...nsOnlyOptions };
+        const tree = schematicRunner.runSchematic('module', options, appTree);
+
+        expect(tree.exists(commonFilePath)).toBeFalsy();
+      });
+
+      it('should respect passed extension', () => {
+        const customExtension = '.mobile';
+        const options = { ...nsOnlyOptions, nsExtension: customExtension, routing: true };
+        const tree = schematicRunner.runSchematic('module', options, appTree);
+
+        const modulePath = getModulePath(customExtension);
+        expect(tree.exists(modulePath)).toBeTruthy();
+
+        const routingModulePath = getRoutingModulePath(customExtension);
+        expect(tree.exists(routingModulePath)).toBeTruthy();
+      });
     });
 
     describe('executing web-only schematic', () => {

--- a/src/generate/module/index_spec.ts
+++ b/src/generate/module/index_spec.ts
@@ -14,7 +14,7 @@ describe('Module Schematic', () => {
   const moduleClassName = toNgModuleClassName(name);
   const defaultOptions: ModuleOptions = {
     project,
-    name,
+    name
   };
   const schematicRunner = new SchematicTestRunner(
     'nativescript-schematics',

--- a/src/generate/module/schema.d.ts
+++ b/src/generate/module/schema.d.ts
@@ -53,6 +53,10 @@ export interface Schema {
   */
   flat?: boolean;
   /**
+   * FLag to control if a common file is created.
+   */
+  common?: boolean;
+  /**
   * Flag to control whether the CommonModule is imported.
   */
   commonModule?: boolean;

--- a/src/generate/module/schema.d.ts
+++ b/src/generate/module/schema.d.ts
@@ -53,7 +53,8 @@ export interface Schema {
   */
   flat?: boolean;
   /**
-   * FLag to control if a common file is created.
+   * Flag to control if a common file is created.
+   * The common file exports components, providers and routes common for both Web and NativeScript.
    */
   common?: boolean;
   /**

--- a/src/generate/module/schema.json
+++ b/src/generate/module/schema.json
@@ -65,7 +65,7 @@
     },
     "common": {
       "type": "boolean",
-      "description": "Flag to control if a common file is created.",
+      "description": "Flag to control if a common file is created. The common file exports components, providers and routes common for both Web and NativeScript.",
       "alias": "c"
     },
     "commonModule": {

--- a/src/generate/module/schema.json
+++ b/src/generate/module/schema.json
@@ -22,7 +22,6 @@
       "type": "string",
       "description": "Allows specification of the used extension for web"
     },
-
     "name": {
       "type": "string",
       "description": "The name of the module.",
@@ -63,6 +62,11 @@
       "type": "boolean",
       "description": "Flag to indicate if a dir is created.",
       "default": false
+    },
+    "common": {
+      "type": "boolean",
+      "description": "Flag to control if a common file is created.",
+      "alias": "c"
     },
     "commonModule": {
       "type": "boolean",

--- a/src/generate/utils.ts
+++ b/src/generate/utils.ts
@@ -39,6 +39,8 @@ export interface PlatformUse {
   webReady: boolean;
   /** Dictates if this is a nsOnly project */
   nsOnly: boolean;
+  /** Dictates if this is a webOnly project */
+  webOnly: boolean;
   /** Dictates if the schematic should include {N} scripts */
   useNs: boolean,
   /** Dictates if the schematic should include web scripts */
@@ -49,6 +51,7 @@ export const getPlatformUse = (tree: Tree, options: Options): PlatformUse => {
   const nsReady = isNs(tree);
   const webReady = isWeb(tree);
   const nsOnly = nsReady && !webReady;
+  const webOnly = webReady && !nsReady;
 
   const useNs = !!options.nativescript && nsReady;
   const useWeb = !!options.web && webReady;
@@ -57,6 +60,7 @@ export const getPlatformUse = (tree: Tree, options: Options): PlatformUse => {
     nsReady,
     webReady,
     nsOnly,
+    webOnly,
     useNs,
     useWeb
   }

--- a/src/generate/utils.ts
+++ b/src/generate/utils.ts
@@ -119,6 +119,7 @@ export const removeNsSchemaOptions = (options: Options) => {
   delete duplicate['nativescript'];
   delete duplicate['nsExtension'];
   delete duplicate['webExtension'];
+  delete duplicate['common'];
 
   return duplicate;
 };

--- a/src/migrate-module/index.ts
+++ b/src/migrate-module/index.ts
@@ -52,6 +52,7 @@ const addModuleFile =
         flat: false,
         web: false,
         spec: false,
+        common: true,
       })(tree, context);
 
 const migrateComponents = (moduleInfo: ModuleInfo, project: string) => {


### PR DESCRIPTION
- fix(module): stop generating common files in web/ns only cases
- test(module): add unit tests for ns-only schematic in shared project
- refactor(module): introduce a 'common' flag
- refactor(migrate-module): generate a common file when migrating