### PR TITLE
refactor: rename constant variables to follow the Angular style guide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/schematics",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -924,8 +924,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -943,13 +942,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -962,18 +959,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1076,8 +1070,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1087,7 +1080,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1100,20 +1092,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1130,7 +1119,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1203,8 +1191,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1214,7 +1201,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1290,8 +1276,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1321,7 +1306,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1339,7 +1323,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1378,13 +1361,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/src/add-ns/_sample-files/barcelona/barcelona.common.ts
+++ b/src/add-ns/_sample-files/barcelona/barcelona.common.ts
@@ -4,16 +4,16 @@ import { PlayersComponent } from "./players/players.component";
 import { PlayerDetailComponent } from "./player-detail/player-detail.component";
 import { PlayerService } from './player.service';
 
-export const COMPONENT_DECLARATIONS: any[] = [
+export const componentDeclarations: any[] = [
   PlayersComponent,
   PlayerDetailComponent
 ];
 
-export const PROVIDERS_DECLARATIONS: any[] = [
+export const providerDeclarations: any[] = [
   PlayerService
 ];
 
-export const ROUTES: Routes = [
+export const routes: Routes = [
   { path: 'players', component: PlayersComponent },
   { path: 'player/:id', component: PlayerDetailComponent },
 ];

--- a/src/add-ns/_sample-files/barcelona/barcelona.module__nsext__.ts
+++ b/src/add-ns/_sample-files/barcelona/barcelona.module__nsext__.ts
@@ -2,22 +2,26 @@ import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
 import { NativeScriptCommonModule } from 'nativescript-angular/common';
 import { NativeScriptRouterModule } from 'nativescript-angular/router';
 
-import { ROUTES, COMPONENT_DECLARATIONS, PROVIDERS_DECLARATIONS } from './barcelona.common';
+import {
+  componentDeclarations,
+  providerDeclarations,
+  routes,
+} from './barcelona.common';
 
 @NgModule({
   imports: [
     NativeScriptCommonModule,
     NativeScriptRouterModule,
-    NativeScriptRouterModule.forRoot(ROUTES)
+    NativeScriptRouterModule.forRoot(routes)
   ],
   exports: [
     NativeScriptRouterModule
   ],
   declarations: [
-    ...COMPONENT_DECLARATIONS
+    ...componentDeclarations
   ],
   providers: [
-    ...PROVIDERS_DECLARATIONS
+    ...providerDeclarations
   ],
   schemas: [
     NO_ERRORS_SCHEMA

--- a/src/add-ns/_sample-files/barcelona/barcelona.module__webext__.ts
+++ b/src/add-ns/_sample-files/barcelona/barcelona.module__webext__.ts
@@ -2,22 +2,26 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 
-import { ROUTES, COMPONENT_DECLARATIONS, PROVIDERS_DECLARATIONS } from './barcelona.common';
+import {
+  componentDeclarations,
+  providerDeclarations,
+  routes,
+} from './barcelona.common';
 
 @NgModule({
   imports: [
     CommonModule,
     RouterModule,
-    RouterModule.forRoot(ROUTES)
+    RouterModule.forRoot(routes)
   ],
   exports: [
     RouterModule
   ],
   declarations: [
-    ...COMPONENT_DECLARATIONS
+    ...componentDeclarations
   ],
   providers: [
-    ...PROVIDERS_DECLARATIONS
+    ...componentDeclarations
   ]
 })
 export class BarcelonaModule { }

--- a/src/generate-template/master-detail/_files-nsonly/__name__/__master__.module.ts
+++ b/src/generate-template/master-detail/_files-nsonly/__name__/__master__.module.ts
@@ -7,7 +7,7 @@ import { <%= masterClassName %>Component } from './<%= master %>/<%= master %>.c
 import { <%= detailClassName %>DetailComponent } from './<%= detail %>-detail/<%= detail %>-detail.component';
 import { DataService } from './data.service';
 
-export const ROUTES: Routes = [
+export const routes: Routes = [
   { path: '<%= master %>', component: <%= masterClassName %>Component },
   { path: '<%= detail %>/:id', component: <%= detailClassName %>DetailComponent },
 ];
@@ -16,7 +16,7 @@ export const ROUTES: Routes = [
   imports: [
     NativeScriptCommonModule,
     NativeScriptRouterModule,
-    NativeScriptRouterModule.forRoot(ROUTES)
+    NativeScriptRouterModule.forRoot(routes)
   ],
   exports: [
     NativeScriptRouterModule

--- a/src/generate-template/master-detail/_files-shared/__name__/__master__.common.ts
+++ b/src/generate-template/master-detail/_files-shared/__name__/__master__.common.ts
@@ -4,16 +4,16 @@ import { <%= masterClassName %>Component } from './<%= master %>/<%= master %>.c
 import { <%= detailClassName %>DetailComponent } from './<%= detail %>-detail/<%= detail %>-detail.component';
 import { DataService } from './data.service';
 
-export const COMPONENT_DECLARATIONS: any[] = [
+export const componentDeclarations: any[] = [
   <%= masterClassName %>Component,
   <%= detailClassName %>DetailComponent
 ];
 
-export const PROVIDERS_DECLARATIONS: any[] = [
+export const providerDeclarations: any[] = [
   DataService
 ];
 
-export const ROUTES: Routes = [
+export const routes: Routes = [
   { path: '<%= master %>', component: <%= masterClassName %>Component },
   { path: '<%= detail %>/:id', component: <%= detailClassName %>DetailComponent },
 ];

--- a/src/generate-template/master-detail/_files-shared/__name__/__master__.module.__nsext__.ts
+++ b/src/generate-template/master-detail/_files-shared/__name__/__master__.module.__nsext__.ts
@@ -2,22 +2,26 @@ import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
 import { NativeScriptCommonModule } from 'nativescript-angular/common';
 import { NativeScriptRouterModule } from 'nativescript-angular/router';
 
-import { ROUTES, COMPONENT_DECLARATIONS, PROVIDERS_DECLARATIONS } from './<%= master %>.common';
+import {
+  componentDeclarations,
+  providerDeclarations,
+  routes,
+} from './<%= master %>.common';
 
 @NgModule({
   imports: [
     NativeScriptCommonModule,
     NativeScriptRouterModule,
-    NativeScriptRouterModule.forRoot(ROUTES)
+    NativeScriptRouterModule.forRoot(routes)
   ],
   exports: [
     NativeScriptRouterModule
   ],
   declarations: [
-    ...COMPONENT_DECLARATIONS
+    ...componentDeclarations
   ],
   providers: [
-    ...PROVIDERS_DECLARATIONS
+    ...providerDeclarations
   ],
   schemas: [
     NO_ERRORS_SCHEMA

--- a/src/generate-template/master-detail/_files-shared/__name__/__master__.module.ts
+++ b/src/generate-template/master-detail/_files-shared/__name__/__master__.module.ts
@@ -2,21 +2,25 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 
-import { ROUTES, COMPONENT_DECLARATIONS, PROVIDERS_DECLARATIONS } from './<%= master %>.common';
+import {
+  componentDeclarations,
+  providerDeclarations,
+  routes,
+} from './<%= master %>.common';
 
 @NgModule({
   imports: [
     CommonModule,
-    RouterModule.forRoot(ROUTES)
+    RouterModule.forRoot(routes)
   ],
   exports: [
     RouterModule
   ],
   declarations: [
-    ...COMPONENT_DECLARATIONS
+    ...componentDeclarations
   ],
   providers: [
-    ...PROVIDERS_DECLARATIONS
+    ...providerDeclarations
   ]
 })
 export class <%= masterClassName %>Module { }

--- a/src/generate/module/_files/__name__.common.ts
+++ b/src/generate/module/_files/__name__.common.ts
@@ -1,10 +1,10 @@
 import { Routes } from '@angular/router';
 
-export const COMPONENT_DECLARATIONS: any[] = [
+export const componentDeclarations: any[] = [
 ];
 
-export const PROVIDERS_DECLARATIONS: any[] = [
+export const providerDeclarations: any[] = [
 ];
 
-export const ROUTES: Routes = [
+export const routes: Routes = [
 ];

--- a/src/ng-new/shared/_sample-files/barcelona/barcelona.common.ts
+++ b/src/ng-new/shared/_sample-files/barcelona/barcelona.common.ts
@@ -4,16 +4,16 @@ import { PlayersComponent } from "./players/players.component";
 import { PlayerDetailComponent } from "./player-detail/player-detail.component";
 import { PlayerService } from './player.service';
 
-export const COMPONENT_DECLARATIONS: any[] = [
+export const componentDeclarations: any[] = [
   PlayersComponent,
   PlayerDetailComponent
 ];
 
-export const PROVIDERS_DECLARATIONS: any[] = [
+export const providerDeclarations: any[] = [
   PlayerService
 ];
 
-export const ROUTES: Routes = [
+export const routes: Routes = [
   { path: 'players', component: PlayersComponent },
   { path: 'player/:id', component: PlayerDetailComponent },
 ];

--- a/src/ng-new/shared/_sample-files/barcelona/barcelona.module.tns.ts
+++ b/src/ng-new/shared/_sample-files/barcelona/barcelona.module.tns.ts
@@ -2,22 +2,26 @@ import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
 import { NativeScriptCommonModule } from 'nativescript-angular/common';
 import { NativeScriptRouterModule } from 'nativescript-angular/router';
 
-import { ROUTES, COMPONENT_DECLARATIONS, PROVIDERS_DECLARATIONS } from './barcelona.common';
+import {
+  componentDeclarations,
+  providerDeclarations,
+  routes,
+} from './barcelona.common';
 
 @NgModule({
   imports: [
     NativeScriptCommonModule,
     NativeScriptRouterModule,
-    NativeScriptRouterModule.forRoot(ROUTES)
+    NativeScriptRouterModule.forRoot(routes)
   ],
   exports: [
     NativeScriptRouterModule
   ],
   declarations: [
-    ...COMPONENT_DECLARATIONS
+    ...componentDeclarations
   ],
   providers: [
-    ...PROVIDERS_DECLARATIONS
+    ...providerDeclarations
   ],
   schemas: [
     NO_ERRORS_SCHEMA

--- a/src/ng-new/shared/_sample-files/barcelona/barcelona.module.ts
+++ b/src/ng-new/shared/_sample-files/barcelona/barcelona.module.ts
@@ -2,21 +2,25 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 
-import { ROUTES, COMPONENT_DECLARATIONS, PROVIDERS_DECLARATIONS } from './barcelona.common';
+import {
+  componentDeclarations,
+  providerDeclarations,
+  routes,
+} from './barcelona.common';
 
 @NgModule({
   imports: [
     CommonModule,
-    RouterModule.forRoot(ROUTES)
+    RouterModule.forRoot(routes)
   ],
   exports: [
     RouterModule
   ],
   declarations: [
-    ...COMPONENT_DECLARATIONS
+    ...componentDeclarations
   ],
   providers: [
-    ...PROVIDERS_DECLARATIONS
+    ...providerDeclarations
   ]
 })
 export class BarcelonaModule { }


### PR DESCRIPTION
When declaring constants it's prefered to use lower camel case variable names (`heroRoutes`) instead of UPPER_SNAKE_CASE (`HERO_ROUTES`). https://angular.io/guide/styleguide#constants