### PR TITLE
Manually import newly created components in the right NgModules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ jasmine-config/**/*.js.map
 # IDEs
 .idea/
 jsconfig.json
-.vscode/
 .history
 
 # Misc

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Test",
+            "program": "${workspaceFolder}/node_modules/jasmine/bin/jasmine.js",
+            "args": [
+                "--config=jasmine-config/jasmine.json"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ]
+        }
+    ]
+}

--- a/src/ast-utils.ts
+++ b/src/ast-utils.ts
@@ -22,22 +22,6 @@ class RemoveContent implements Node {
   }
 }
 
-export function addSymbolToComponentMetadata(
-  source: ts.SourceFile,
-  componentPath: string,
-  metadataField: string,
-  symbolName: string,
-): Change[] {
-  return addSymbolToDecoratorMetadata(
-    source,
-    componentPath,
-    metadataField,
-    symbolName,
-    'Component',
-    '@angular/core'
-  );
-}
-
 // Almost identical to addSymbolToNgModuleMetadata from @schematics/angular/utility/ast-utils
 // the method can be refactored so that it can be used with custom decorators
 export function addSymbolToDecoratorMetadata(
@@ -630,19 +614,6 @@ export function findImportPath(source: ts.Node, name) {
   return moduleSpecifier.text;
 }
 
-export const insertModuleId = (tree: Tree, component: string) => {
-  const componentSource = getSourceFile(tree, component);
-  const recorder = tree.beginUpdate(component);
-
-  const metadataChange = addSymbolToComponentMetadata(
-    componentSource, component, 'moduleId', 'module.id');
-
-  metadataChange.forEach((change: InsertChange) =>
-    recorder.insertRight(change.pos, change.toAdd)
-  );
-  tree.commitUpdate(recorder);
-
-};
 
 export const updateNodeText = (tree: Tree, node: ts.Node, newText: string) => {
   const recorder = tree.beginUpdate(node.getSourceFile().fileName);

--- a/src/generate/component/ast-utils.ts
+++ b/src/generate/component/ast-utils.ts
@@ -1,0 +1,87 @@
+import * as ts from 'typescript';
+
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
+import { classify } from '@angular-devkit/core/src/utils/strings';
+import { buildRelativePath } from '@schematics/angular/utility/find-module';
+import { InsertChange, Change } from '@schematics/angular/utility/change';
+import { addEntryComponentToModule, addExportToModule, addDeclarationToModule } from '@schematics/angular/utility/ast-utils';
+import { Schema as ComponentOptions } from './schema';
+import { getSourceFile } from '../../utils';
+import { addSymbolToDecoratorMetadata } from '../../ast-utils';
+
+export const insertModuleId = (tree: Tree, component: string) => {
+  const componentSource = getSourceFile(tree, component);
+  const recorder = tree.beginUpdate(component);
+
+  const metadataChange = addSymbolToComponentMetadata(
+    componentSource, component, 'moduleId', 'module.id');
+
+  metadataChange.forEach((change: InsertChange) =>
+    recorder.insertRight(change.pos, change.toAdd)
+  );
+  tree.commitUpdate(recorder);
+};
+
+function addSymbolToComponentMetadata(
+  source: ts.SourceFile,
+  componentPath: string,
+  metadataField: string,
+  symbolName: string,
+): Change[] {
+  return addSymbolToDecoratorMetadata(
+    source,
+    componentPath,
+    metadataField,
+    symbolName,
+    'Component',
+    '@angular/core'
+  );
+}
+
+export function addDeclarationToNgModule(tree: Tree, options: ComponentOptions, componentPath: string, modulePath: string) {
+  const source = readIntoSourceFile(tree, modulePath);
+  const relativePath = buildRelativePath(modulePath, componentPath);
+  const classifiedName = classify(`${options.name}Component`);
+  const declarationChanges = addDeclarationToModule(source, modulePath, classifiedName, relativePath);
+  const declarationRecorder = tree.beginUpdate(modulePath);
+  for (const change of declarationChanges) {
+    if (change instanceof InsertChange) {
+      declarationRecorder.insertLeft(change.pos, change.toAdd);
+    }
+  }
+  tree.commitUpdate(declarationRecorder);
+  if (options.export) {
+    // Need to refresh the AST because we overwrote the file in the host.
+    const source = readIntoSourceFile(tree, modulePath);
+    const exportRecorder = tree.beginUpdate(modulePath);
+    const exportChanges = addExportToModule(source, modulePath, classify(`${options.name}Component`), relativePath);
+    for (const change of exportChanges) {
+      if (change instanceof InsertChange) {
+        exportRecorder.insertLeft(change.pos, change.toAdd);
+      }
+    }
+    tree.commitUpdate(exportRecorder);
+  }
+  if (options.entryComponent) {
+    // Need to refresh the AST because we overwrote the file in the host.
+    const source = readIntoSourceFile(tree, modulePath);
+    const entryComponentRecorder = tree.beginUpdate(modulePath);
+    const entryComponentChanges = addEntryComponentToModule(source, modulePath, classify(`${options.name}Component`), relativePath);
+    for (const change of entryComponentChanges) {
+      if (change instanceof InsertChange) {
+        entryComponentRecorder.insertLeft(change.pos, change.toAdd);
+      }
+    }
+    tree.commitUpdate(entryComponentRecorder);
+  }
+}
+
+function readIntoSourceFile(host: Tree, modulePath: string): ts.SourceFile {
+  const text = host.read(modulePath);
+  if (text === null) {
+    throw new SchematicsException(`File ${modulePath} does not exist.`);
+  }
+  const sourceText = text.toString('utf-8');
+
+  return ts.createSourceFile(modulePath, sourceText, ts.ScriptTarget.Latest, true);
+}

--- a/src/generate/component/find-module.ts
+++ b/src/generate/component/find-module.ts
@@ -1,0 +1,60 @@
+import { dirname } from 'path';
+
+import { Tree, DirEntry } from "@angular-devkit/schematics";
+import { join, normalize } from '@angular-devkit/core';
+import { dasherize } from '@angular-devkit/core/src/utils/strings';
+
+import { Schema as ComponentOptions } from './schema';
+
+export function findModule(tree: Tree, options: ComponentOptions, path: string, extension: string) {
+  if (options.module) {
+    return findExplicitModule(tree, path, extension, options.module);
+  } else {
+    const pathToCheck = (path || '')
+      + (options.flat ? '' : '/' + dasherize(options.name));
+
+    return findImplicitModule(tree, pathToCheck, extension);
+  }
+}
+
+function findExplicitModule(tree: Tree, path: string, extension: string, moduleName: string) {
+  while (path) {
+    const modulePath = normalize(`/${path}/${moduleName}`);
+    const moduleBaseName = normalize(modulePath).split('/').pop();
+
+    if (tree.exists(modulePath)) {
+      return normalize(modulePath);
+    } else if (tree.exists(modulePath + extension + '.ts')) {
+      return normalize(modulePath + extension + '.ts');
+    } else if (tree.exists(modulePath + '.module' + extension + '.ts')) {
+      return normalize(modulePath + '.module' + extension + '.ts');
+    } else if (tree.exists(modulePath + '/' + moduleBaseName + '.module' + extension + '.ts')) {
+      return normalize(modulePath + '/' + moduleBaseName + '.module' + extension + '.ts');
+    }
+
+    path = dirname(path);
+  }
+
+  throw new Error('Specified module does not exist');
+}
+
+function findImplicitModule(tree: Tree, path: string, extension: string) {
+    let dir: DirEntry | null = tree.getDir(`/${path}`);
+
+    const moduleRe = new RegExp(`.module${extension}.ts`);
+    const routingModuleRe = new RegExp(`-routing.module${extension}.ts`);
+
+    while (dir) {
+      const matches = dir.subfiles.filter(p => moduleRe.test(p) && !routingModuleRe.test(p));
+      if (matches.length == 1) {
+        return join(dir.path, matches[0]);
+      } else if (matches.length > 1) {
+        throw new Error('More than one module matches. Use skip-import option to skip importing '
+          + 'the component into the closest module.');
+      }
+
+      dir = dir.parent;
+    }
+    throw new Error('Could not find an NgModule. Use the skip-import '
+      + 'option to skip importing in NgModule.');
+}

--- a/src/generate/component/index.ts
+++ b/src/generate/component/index.ts
@@ -42,15 +42,20 @@ export default function (options: ComponentOptions): Rule {
         options.spec = false;
       }
 
+      if (
+        !platformUse.nsOnly && // the project is shared
+        platformUse.useNs && !platformUse.useWeb // the new component is only for {N}
+      ) {
+        options.skipImport = true; // don't declare it in the web NgModule
+      }
+
       validateGenerateOptions(platformUse, options);
       validateGenerateComponentOptions(platformUse, options);
 
       return tree;
     },
 
-    () => {
-      return externalSchematic('@schematics/angular', 'component', removeNsSchemaOptions(options));
-    },
+    () => externalSchematic('@schematics/angular', 'component', removeNsSchemaOptions(options)),
 
     (tree: Tree) => {
       extensions = getExtensions(tree, options);

--- a/src/migrate-component/component-info-utils.ts
+++ b/src/migrate-component/component-info-utils.ts
@@ -27,7 +27,7 @@ export const parseComponentInfo = (options: MigrateComponentSchema) => (tree: Tr
     ? options.name
     : classify(`${options.name}Component`);
 
-  // if no module provided and skipModule flag is on, then don't search for module path
+  // if no module is provided and the skipModule flag is on, then don't search for module path
   const modulePath = (!options.module && options.skipModule) ? '' : findModulePath(options, tree);
 
   const componentPath = findComponentPath(className, modulePath, options, tree);
@@ -123,7 +123,11 @@ const findComponentPath = (componentClassName: string, modulePath: string, optio
     const componentImportPath = findImportPath(source, componentClassName);
     console.log(`${componentClassName} import found in its module at: ${componentImportPath}`);
     
-    componentPath = join(dirname(modulePath), componentImportPath + '.ts')
+    componentPath = join(dirname(modulePath), componentImportPath);
+    if (!componentPath.endsWith('.ts')) {
+      componentPath = componentPath + '.ts';
+    }
+
     if (tree.exists(componentPath)) {
       console.log(`${componentClassName} file found at: ${componentPath}`);
     } else {

--- a/src/migrate-component/index.ts
+++ b/src/migrate-component/index.ts
@@ -85,8 +85,8 @@ const addComponentToNsModuleProviders = (componentInfo: ComponentInfo, options: 
   // check if the {N} version of the @NgModule exists
   if (!tree.exists(nsModulePath)) {
     throw new SchematicsException(`Module file [${nsModulePath}] doesn't exist.
-Create it if you want the schematic to add ${componentInfo.className} to its' module declarations,
-or if you just want to update the component without updating its' module, then rerun this command with --skip-module flag`);
+Create it if you want the schematic to add ${componentInfo.className} to its module declarations,
+or if you just want to update the component without updating its module, then rerun this command with --skip-module flag`);
   }
 
   // Get the changes required to update the @NgModule

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -173,6 +173,7 @@ export function createEmptyNsOnlyProject(projectName: string): UnitTestTree {
 
 export function createEmptySharedProject(projectName: string): UnitTestTree {
   let appTree = createEmptyNsOnlyProject(projectName);
+  appTree = createAppModule(<any>appTree, `/src/app/app.module.tns.ts`);
 
   appTree.create('/nsconfig.json', JSON.stringify({
     "appResourcesPath": "App_Resources",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -153,10 +153,10 @@ export const renameFilesForce = (paths: FromTo[]) =>
     tree.delete(from);
   });
 
-export function createEmptyNsOnlyProject(projectName: string): UnitTestTree {
+export function createEmptyNsOnlyProject(projectName: string, extension: string = ''): UnitTestTree {
   let appTree = schematicRunner.runSchematic("angular-json", { name: projectName, sourceRoot: "src" });
 
-  appTree = createAppModule(<any>appTree, `/src/app/app.module.ts`);
+  appTree = createAppModule(<any>appTree, `/src/app/app.module${extension}.ts`);
 
   appTree.create('/package.json', JSON.stringify({
     nativescript: { id: "proj" },
@@ -171,9 +171,9 @@ export function createEmptyNsOnlyProject(projectName: string): UnitTestTree {
   return appTree;
 }
 
-export function createEmptySharedProject(projectName: string): UnitTestTree {
-  let appTree = createEmptyNsOnlyProject(projectName);
-  appTree = createAppModule(<any>appTree, `/src/app/app.module.tns.ts`);
+export function createEmptySharedProject(projectName: string, webExtension: string = '', nsExtension: string = '.tns'): UnitTestTree {
+  let appTree = createEmptyNsOnlyProject(projectName, nsExtension);
+  appTree = createAppModule(<any>appTree, `/src/app/app.module${webExtension}.ts`);
 
   appTree.create('/nsconfig.json', JSON.stringify({
     "appResourcesPath": "App_Resources",


### PR DESCRIPTION
Before we were delegating the task of declaring new components inside an NgModule to the external `component` schematic. However, this causes two problems:
- If a custom web extension is used for the web files (f.e. `app.module.web.ts`), the external schematic won't find an NgModule to declare the new component in. That's because the external schematic looks only for files ending with `.module.ts`.
- The component won't be declared inside the {N} module (`app.module.tns.ts`).

With these changes, the external component schematic is always called with `skipImport: true` and the new component is manually declared inside an appropriate NgModule (web, mobile or both).

The PR also adds a simple VSCode launch configuration for debugging unit tests.

fixes #78, #54