### PR TITLE
chore(shared/tsconfig.json): include types option.

### DIFF
--- a/src/ng-new/shared/_files/tsconfig.json
+++ b/src/ng-new/shared/_files/tsconfig.json
@@ -11,6 +11,11 @@
     "typeRoots": [
       "node_modules/@types"
     ],
+    "types": [
+      "jasmine",
+      "jasminewd2",
+      "node"
+    ],
     "lib": [
       "es2017",
       "dom"


### PR DESCRIPTION
Hey @sis0k0, @sebawita, I have tested running e2e tests with nativescript-dev-appium plugin within a shared project and it seems that there are some collisions between typings that nativescript-dev-appium plugin requires and angular tests.
Also, this will enable of running simultaniously 
`tns run android/ ios --hmr`
and
`npm run appium -- --runType android28/sim.IPhone.XR --devMode`