### PR TITLE
chore: change e2e command to ng-e2e

### DIFF
--- a/src/ng-new/shared/_files/package.json
+++ b/src/ng-new/shared/_files/package.json
@@ -10,7 +10,7 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e",
+    "ng-e2e": "ng e2e",
     "android": "tns run android --bundle",
     "ios": "tns run ios --bundle"
   },


### PR DESCRIPTION
This is a proposal to change `npm run e2e` command which executes `ng e2e` to` npm run ng-e2e`, since nativescript-dev-appium plugin uses the same command.
