### PR TITLE
feat: generate stylesheets when migrating components and modules

### DIFF
--- a/src/migrate-component/_ns-style/__path__/__styleFileName@addNsExtension__
+++ b/src/migrate-component/_ns-style/__path__/__styleFileName@addNsExtension__
@@ -1,0 +1,5 @@
+/*
+Add your NativeScript specific styles here.
+To learn more about styling in NativeScript see:
+https://docs.nativescript.org/angular/ui/styling
+*/

--- a/src/migrate-component/index_spec.ts
+++ b/src/migrate-component/index_spec.ts
@@ -29,6 +29,7 @@ describe('Migrate component schematic', () => {
         const options: MigrateComponentOptions = {
             project,
             name: componentName,
+            style: true
         };
         const htmlComponentPath = `/src/app/${componentName}/${componentName}.component.html`;
         const xmlComponentPath = `/src/app/${componentName}/${componentName}.component.tns.html`;
@@ -70,6 +71,7 @@ describe('Migrate component schematic', () => {
             project,
             name: componentName,
             module: moduleName,
+            style: true
         };
         const htmlComponentPath = `/src/app/${componentName}/${componentName}.component.html`;
         const xmlComponentPath = `/src/app/${componentName}/${componentName}.component.tns.html`;

--- a/src/migrate-component/schema.d.ts
+++ b/src/migrate-component/schema.d.ts
@@ -19,7 +19,10 @@ export interface Schema {
   * Notifies us that the component doesn't belong to any module.
   */
   skipModule?: boolean;
-  
+  /**
+   * Specifies whether stylesheets should be generated.
+   */
+  style: boolean;
   nsext?: string;
   webext?: string;
   /**

--- a/src/migrate-component/schema.json
+++ b/src/migrate-component/schema.json
@@ -22,6 +22,10 @@
     "skipModule": {
       "type": "boolean"
     },
+    "style": {
+      "type": "boolean",
+      "default": true
+    },
     "nsext": {
       "type": "string"
     },

--- a/src/migrate-module/index.ts
+++ b/src/migrate-module/index.ts
@@ -37,7 +37,7 @@ export default function(options: MigrateModuleSchema): Rule {
 
     addModuleFile(options.name, options.project),
 
-    (tree, context) => migrateComponents(moduleInfo, options.project)(tree, context),
+    (tree, context) => migrateComponents(moduleInfo, options)(tree, context),
     migrateProviders()
   ]);
 }
@@ -55,7 +55,7 @@ const addModuleFile =
         common: true,
       })(tree, context);
 
-const migrateComponents = (moduleInfo: ModuleInfo, project: string) => {
+const migrateComponents = (moduleInfo: ModuleInfo, options: MigrateModuleSchema) => {
   const components = moduleInfo.declarations.filter(d => d.name.endsWith('Component'));
 
   return chain(
@@ -64,7 +64,8 @@ const migrateComponents = (moduleInfo: ModuleInfo, project: string) => {
         name: component.name,
         modulePath: moduleInfo.modulePath,
         nsext,
-        project,
+        project: options.project,
+        style: options.style
       }
       return schematic<MigrateComponentSchema>('migrate-component', convertComponentOptions);
     }),

--- a/src/migrate-module/index_spec.ts
+++ b/src/migrate-module/index_spec.ts
@@ -19,6 +19,7 @@ describe('Migrate module Schematic', () => {
   const defaultOptions: MigrateModuleOptions = {
     name: moduleName,
     project,
+    style: true
   };
   const nsModulePath = '/src/app/admin/admin.module.tns.ts';
   const webModulePath = '/src/app/admin/admin.module.ts';

--- a/src/migrate-module/schema.d.ts
+++ b/src/migrate-module/schema.d.ts
@@ -7,6 +7,10 @@ export interface Schema {
   * Specifies the module path.
   */
   modulePath?: string;
+  /**
+  * Specifies whether stylesheets should be generated for all components.
+  */
+  style: boolean;
   nsext?: string;
   /**
   * Allows specification of the project to be updated

--- a/src/migrate-module/schema.json
+++ b/src/migrate-module/schema.json
@@ -12,6 +12,10 @@
       "type": "string",
       "alias": "p"
     },
+    "style": {
+      "type": "boolean",
+      "default": true
+    },
     "nsext": {
       "type": "string"
     },


### PR DESCRIPTION
use `--no-style` to skip the generation of [css | scss] files