### PR TITLE
refactor: update to Angular 7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@angular-devkit/core": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-7.0.1.tgz",
-      "integrity": "sha512-IUzp2NdMJi4kqmYEZJeW3POzZGEv5QvSuiFqNpKXTztnXNRS9a91aPLYbfKlcYYsQ7ggguMRoaNbF33FzjKPUw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-7.1.3.tgz",
+      "integrity": "sha512-pGBInxmuR5DAhZ1RSfIlkv7cdgh3EDNXXea9ZObEuI9MuFsIWUKODT5oKbRrsOWM6IqwNmx68VEW+xQm2DXyJw==",
       "requires": {
         "ajv": "6.5.3",
         "chokidar": "2.0.4",
@@ -24,22 +24,29 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-7.0.1.tgz",
-      "integrity": "sha512-hjFtd0TSA4xBeM0MBEVD6bntCwHfJTKwPd03FiYm/bTbkEXxVGKcocNfOxf6g/+Mtp0rUhQHsxJdagewEagBaQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-7.1.3.tgz",
+      "integrity": "sha512-Snmfog/n5k1PWdDaI+Top1F978vlXZFTvxHRPzlMCGhGsY+LMOpeRLVHADI+WP1q1LZ+2BjLELZVA2GP35AH8A==",
       "requires": {
-        "@angular-devkit/core": "7.0.1",
+        "@angular-devkit/core": "7.1.3",
         "rxjs": "6.3.3"
       }
     },
     "@schematics/angular": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-7.0.1.tgz",
-      "integrity": "sha512-IJd7nT5+w3IkJOzXMvgevGJk3HnqoUKOessT3epTEoPvuTLGxljqVNDAaT3KSDDA1lDqTsLIXuT6kK2L5OJO1g==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-7.1.3.tgz",
+      "integrity": "sha512-6Wq6vNjGTc0zmudPogTjiegtTUc0pORTCxI39iinUM+5iemMrCLYKJmYLi5mPFU4OG/Q2fnT06A3dYUorhtLkA==",
       "requires": {
-        "@angular-devkit/core": "7.0.1",
-        "@angular-devkit/schematics": "7.0.1",
-        "typescript": "3.1.3"
+        "@angular-devkit/core": "7.1.3",
+        "@angular-devkit/schematics": "7.1.3",
+        "typescript": "3.1.6"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+          "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA=="
+        }
       }
     },
     "@types/jasmine": {
@@ -953,13 +960,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -972,18 +977,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1086,8 +1088,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1097,7 +1098,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1110,20 +1110,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1140,7 +1137,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1213,8 +1209,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1224,7 +1219,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1330,7 +1324,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2567,7 +2560,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "requires": {
         "ret": "~0.1.10"
@@ -2912,7 +2905,8 @@
     "typescript": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.3.tgz",
-      "integrity": "sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA=="
+      "integrity": "sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==",
+      "dev": true
     },
     "uglify-js": {
       "version": "2.8.29",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   },
   "schematics": "./src/collection.json",
   "dependencies": {
-    "@angular-devkit/core": "~7.0.0",
-    "@angular-devkit/schematics": "~7.0.0",
-    "@schematics/angular": "~7.0.0"
+    "@angular-devkit/core": "~7.1.3",
+    "@angular-devkit/schematics": "~7.1.3",
+    "@schematics/angular": "~7.1.3"
   },
   "devDependencies": {
     "@types/jasmine": "^2.6.0",


### PR DESCRIPTION
This PR bumps the versions of the Angular tooling dependencies. No changes in the code are needed.