### PR TITLE
fix: resolve main.tns.ts with webpack's VFS instead with TS

### DIFF
--- a/src/add-ns/_ns-files/__sourceDir__/package.json
+++ b/src/add-ns/_ns-files/__sourceDir__/package.json
@@ -2,7 +2,7 @@
   "android": {
     "v8Flags": "--expose_gc"
   },
-  "main": "<%= main %><%= nsext %>.js",
+  "main": "<%= main %>.js",
   "name": "migration-ng",
   "version": "4.1.0"
 }

--- a/src/add-ns/_ns-files/tsconfig__nsext__.json
+++ b/src/add-ns/_ns-files/tsconfig__nsext__.json
@@ -13,8 +13,5 @@
         "./node_modules/*"
       ]
     }
-  },
-  "files": [
-      "src/main<%= nsext %>.ts"
-  ]
+  }
 }

--- a/src/add-ns/_ns-files/tsconfig__nsext__.json
+++ b/src/add-ns/_ns-files/tsconfig__nsext__.json
@@ -13,5 +13,11 @@
         "./node_modules/*"
       ]
     }
-  }
+  },
+   "exclude": [
+    "**/*.tns.ts",
+    "**/*.android.ts",
+    "**/*.ios.ts",
+    "**/*.spec.ts"
+  ]
 }

--- a/src/ng-new/shared/_files/__sourcedir__/package.json
+++ b/src/ng-new/shared/_files/__sourcedir__/package.json
@@ -2,7 +2,7 @@
   "android": {
     "v8Flags": "--expose_gc"
   },
-  "main": "main.tns.js",
+  "main": "main.js",
   "name": "migration-ng",
   "version": "4.1.0"
 }

--- a/src/ng-new/shared/_files/tsconfig.tns.json
+++ b/src/ng-new/shared/_files/tsconfig.tns.json
@@ -3,8 +3,5 @@
   "compilerOptions": {
     "module": "es2015",
     "moduleResolution": "node"
-  },
-  "files": [
-    "src/main.tns.ts"
-  ]
+  }
 }


### PR DESCRIPTION
This PR unifies the TypeScript configs for normal and code-sharing {N} apps. This should fix #173.

fixes #173