### PR TITLE
chore: add an npm script for tns preview

### DIFF
--- a/src/add-ns/index.ts
+++ b/src/add-ns/index.ts
@@ -213,7 +213,8 @@ const addRunScriptsToPackageJson = (tree: Tree, context: SchematicContext) => {
 
   const scriptsToAdd = {
     android: 'tns run android --bundle',
-    ios: 'tns run ios --bundle'
+    ios: 'tns run ios --bundle',
+    preview: 'tns preview --bundle'
   };
   packageJson.scripts = Object.assign({}, scriptsToAdd, packageJson.scripts);
 

--- a/src/add-ns/index.ts
+++ b/src/add-ns/index.ts
@@ -214,6 +214,7 @@ const addRunScriptsToPackageJson = (tree: Tree, context: SchematicContext) => {
   const scriptsToAdd = {
     android: 'tns run android --bundle',
     ios: 'tns run ios --bundle',
+    mobile: 'tns run --bundle',
     preview: 'tns preview --bundle'
   };
   packageJson.scripts = Object.assign({}, scriptsToAdd, packageJson.scripts);

--- a/src/ng-new/shared/_files/package.json
+++ b/src/ng-new/shared/_files/package.json
@@ -13,8 +13,8 @@
     "e2e": "ng e2e",
     "android": "tns run android --bundle",
     "ios": "tns run ios --bundle",
-    "mobile": 'tns run --bundle',
-    "preview": 'tns preview --bundle'
+    "mobile": "tns run --bundle",
+    "preview": "tns preview --bundle"
   },
   "private": true,
   "dependencies": {

--- a/src/ng-new/shared/_files/package.json
+++ b/src/ng-new/shared/_files/package.json
@@ -12,7 +12,9 @@
     "lint": "ng lint",
     "e2e": "ng e2e",
     "android": "tns run android --bundle",
-    "ios": "tns run ios --bundle"
+    "ios": "tns run ios --bundle",
+    "mobile": 'tns run --bundle',
+    "preview": 'tns preview --bundle'
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
The new npm script will allow devs to call `npm run preview`, which will execute `tns preview --bundle`