### PR TITLE
chore: speed up `ng generate component` schematic

### DIFF
--- a/src/generate/component/index.ts
+++ b/src/generate/component/index.ts
@@ -11,7 +11,6 @@ import {
   template,
   url,
   mergeWith,
-  filter,
 } from '@angular-devkit/schematics';
 
 import { dasherize } from '@angular-devkit/core/src/utils/strings';
@@ -58,7 +57,7 @@ export default function (options: ComponentOptions): Rule {
       extensions = getExtensions(tree, options);
       componentInfo = parseComponentInfo(tree, options);
     },
-    
+
     (tree: Tree) => {
       if (options.skipImport) {
         return tree;
@@ -90,17 +89,17 @@ export default function (options: ComponentOptions): Rule {
 
     (tree: Tree, context: SchematicContext) => {
       if (platformUse.useWeb) {
-        return renameFile(tree, componentInfo.templatePath);
+        return addWebExtension(tree, componentInfo.templatePath);
       } else {
-        return removeFile(tree, context, componentInfo.templatePath);
+        return removeFile(tree, componentInfo.templatePath);
       }
     },
 
     (tree: Tree, context: SchematicContext) => {
       if (platformUse.useWeb) {
-        return renameFile(tree, componentInfo.stylesheetPath);
+        return addWebExtension(tree, componentInfo.stylesheetPath);
       } else {
-        return removeFile(tree, context, componentInfo.stylesheetPath);
+        return removeFile(tree, componentInfo.stylesheetPath);
       }
     },
 
@@ -147,7 +146,7 @@ const parseComponentInfo = (tree: Tree, options: ComponentOptions): ComponentInf
   return component;
 }
 
-const renameFile = (tree: Tree, filePath: string) => {
+const addWebExtension = (tree: Tree, filePath: string) => {
   if (extensions.web) {
     const webName = insertExtension(filePath, extensions.web);
     tree.rename(filePath, webName);
@@ -155,10 +154,10 @@ const renameFile = (tree: Tree, filePath: string) => {
   return tree;
 };
 
-const removeFile = (tree: Tree, context: SchematicContext, filePath: string) =>
-  filter(
-    (path: Path) => !path.match(filePath)
-  )(tree, context)
+const removeFile = (tree: Tree, filePath: string) => {
+  tree.delete(filePath);
+  return tree;
+}
 
 const addNativeScriptFiles = (component: ComponentInfo) => {
   const parsedTemplate = parseName('', component.templatePath);


### PR DESCRIPTION
Replace the use of filter() with tree.delete()

This significantly improves the performance of generating components, as filter() is a very slow function, which goes through every single file (including all files in node_modules) to check for the filtering condition.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-schematics/blob/master/CONTRIBUTING.md#running-tests.
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla
