### PR TITLE
feat: use HMR by default for newly created projects

### DIFF
--- a/src/add-ns/_ns-files/nsconfig.json
+++ b/src/add-ns/_ns-files/nsconfig.json
@@ -3,5 +3,6 @@
   "appPath": "<%= sourceDir %>",
   "nsext": "<%= nsext %>",
   "webext": "<%= webext %>",
-  "shared": true
+  "shared": true,
+  "useLegacyWorkflow": false
 }

--- a/src/models/nsconfig.d.ts
+++ b/src/models/nsconfig.d.ts
@@ -3,5 +3,6 @@ export interface NsConfig {
   appPath: string,
   nsext: string,
   webext: string,
-  shared: boolean
+  shared: boolean,
+  useLegacyWorkflow: boolean
 }

--- a/src/ng-new/application/_files/nsconfig.json
+++ b/src/ng-new/application/_files/nsconfig.json
@@ -1,0 +1,4 @@
+{
+  "appPath": "<%= sourcedir %>",
+  "useLegacyWorkflow": false
+}

--- a/src/ng-new/application/index_spec.ts
+++ b/src/ng-new/application/index_spec.ts
@@ -25,6 +25,7 @@ describe('Application Schematic', () => {
     const tree = schematicRunner.runSchematic('application', options);
     const files = tree.files;
     expect(files.indexOf('/foo/angular.json')).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf('/foo/nsconfig.json')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/foo/.gitignore')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/foo/package.json')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/foo/tsconfig.json')).toBeGreaterThanOrEqual(0);

--- a/src/ng-new/shared/_files/nsconfig.json
+++ b/src/ng-new/shared/_files/nsconfig.json
@@ -3,5 +3,6 @@
   "appPath": "<%= sourcedir %>",
   "nsext": ".tns",
   "webext": "",
-  "shared": true
+  "shared": true,
+  "useLegacyWorkflow": false
 }

--- a/src/ng-new/shared/index_spec.ts
+++ b/src/ng-new/shared/index_spec.ts
@@ -23,6 +23,7 @@ describe('Shared Application Schematic', () => {
     const tree = schematicRunner.runSchematic('shared', options);
     const files = tree.files;
     expect(files.indexOf('/foo/angular.json')).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf('/foo/nsconfig.json')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/foo/.gitignore')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/foo/package.json')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/foo/tsconfig.tns.json')).toBeGreaterThanOrEqual(0);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -180,7 +180,8 @@ export function createEmptySharedProject(projectName: string, webExtension: stri
     'appPath': 'src',
     'nsext': '.tns',
     'webext': '',
-    'shared': true
+    'shared': true,
+    'useLegacyWorkflow': false
   }));
 
   return <any>appTree;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-schematics/blob/master/CONTRIBUTING.md#running-tests.
- [ ] Tests for the changes are included.

## What is the current behavior?
The schematics are creating projects with the legacy workflow.

## What is the new behavior?
The schematics are creating projects with the recommended Webpack + HMR workflow enabled by default as we do in all NativeScript 5.4 templates.