### PR TITLE
fix: move all typescript helpers to a separate file - `ts-utils`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ jsconfig.json
 node_modules/
 npm-debug.log*
 yarn-error.log*
+package-lock.json
 
 # Mac OSX Finder files.
 **/.DS_Store

--- a/src/angular-project-parser.ts
+++ b/src/angular-project-parser.ts
@@ -9,8 +9,8 @@ import {
   findBootstrapModulePath,
 } from '@schematics/angular/utility/ng-ast-utils';
 
-import { getSourceFile, safeGet } from './utils';
-import { findNode, findImportPath } from './ast-utils';
+import { safeGet } from './utils';
+import { findNode, findImportPath, getSourceFile } from './ts-utils';
 
 export interface AngularProjectSettings {
   /** default: '' */

--- a/src/convert-relative-imports/index.ts
+++ b/src/convert-relative-imports/index.ts
@@ -6,7 +6,8 @@ import { LoggerApi } from '@angular-devkit/core/src/logger';
 import { PreferMappedImportsRule } from '@nativescript/tslint-rules';
 import { parseCompilerOptions } from '@nativescript/tslint-rules/dist/preferMappedImportsRule';
 
-import { parseTsConfigFile, getFileContents } from '../utils';
+import { parseTsConfigFile } from '../ts-utils';
+import { getFileContents } from '../utils';
 import { getTsConfigFromProject } from '../angular-project-parser';
 import { Schema as ConvertRelativeImportsSchema } from './schema';
 

--- a/src/decorator-utils.ts
+++ b/src/decorator-utils.ts
@@ -1,8 +1,7 @@
 import * as ts from 'typescript';
-import { findNode, findMatchingNodes, findImportPath } from './ast-utils';
 import { Tree } from '@angular-devkit/schematics';
-import { getSourceFile } from './utils';
 
+import { findNode, findMatchingNodes, findImportPath, getSourceFile } from './ts-utils';
 
 export interface ClassImport {
   name: string;

--- a/src/generate-template/master-detail/index_spec.ts
+++ b/src/generate-template/master-detail/index_spec.ts
@@ -5,8 +5,8 @@ import { HostTree } from '@angular-devkit/schematics';
 
 import { Schema as MasterDetailOptions } from './schema';
 import { createEmptyNsOnlyProject, createEmptySharedProject } from '../../test-utils';
-import { getSourceFile, toComponentClassName } from '../../utils';
-import { findImports } from '../../ast-utils';
+import { toComponentClassName } from '../../utils';
+import { getSourceFile, findImports } from '../../ts-utils';
 
 describe('Master-detail schematic', () => {
   const master = 'heroes';

--- a/src/generate/component/ast-utils.ts
+++ b/src/generate/component/ast-utils.ts
@@ -6,8 +6,7 @@ import { buildRelativePath } from '@schematics/angular/utility/find-module';
 import { InsertChange, Change } from '@schematics/angular/utility/change';
 import { addEntryComponentToModule, addExportToModule, addDeclarationToModule } from '@schematics/angular/utility/ast-utils';
 import { Schema as ComponentOptions } from './schema';
-import { getSourceFile } from '../../utils';
-import { addSymbolToDecoratorMetadata } from '../../ast-utils';
+import { addSymbolToDecoratorMetadata, getSourceFile } from '../../ts-utils';
 
 export const insertModuleId = (tree: Tree, component: string) => {
   const componentSource = getSourceFile(tree, component);

--- a/src/generate/component/index_spec.ts
+++ b/src/generate/component/index_spec.ts
@@ -3,12 +3,12 @@ import { join } from 'path';
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
 import { getFileContent } from '@schematics/angular/utility/test';
 
-import { toComponentClassName, getSourceFile } from '../../utils';
+import { toComponentClassName } from '../../utils';
 import { createEmptyNsOnlyProject, createEmptySharedProject } from '../../test-utils';
 import { DEFAULT_SHARED_EXTENSIONS } from '../utils';
 import { isInComponentMetadata, isInModuleMetadata } from '../../test-utils';
 import { Schema as ComponentOptions } from './schema';
-import { findImports } from '../../ast-utils';
+import { findImports, getSourceFile } from '../../ts-utils';
 
 describe('Component Schematic', () => {
   const name = 'foo';

--- a/src/generate/module/index.ts
+++ b/src/generate/module/index.ts
@@ -16,14 +16,12 @@ import { InsertChange } from '@schematics/angular/utility/change';
 import { addSymbolToNgModuleMetadata } from '@schematics/angular/utility/ast-utils';
 
 import { Schema as ModuleOptions } from './schema';
-import {
-  getSourceFile,
-  copy,
-} from '../../utils';
+import { copy } from '../../utils';
 import {
   removeImport,
   removeMetadataArrayValue,
-} from '../../ast-utils';
+  getSourceFile,
+} from '../../ts-utils';
 import { dasherize } from '@angular-devkit/core/src/utils/strings';
 import { removeNsSchemaOptions, getExtensions, PlatformUse, getPlatformUse, Extensions, addExtension, validateGenerateOptions } from '../utils';
 import { parseName } from '@schematics/angular/utility/parse-name';

--- a/src/migrate-component/component-info-utils.ts
+++ b/src/migrate-component/component-info-utils.ts
@@ -6,8 +6,7 @@ import { join, dirname } from 'path';
 import * as ts from 'typescript';
 
 import { AngularProjectSettings, getAngularProjectSettings } from '../angular-project-parser';
-import { getSourceFile } from '../utils';
-import { findImportPath, findMatchingNodes } from '../ast-utils';
+import { findImportPath, findMatchingNodes, getSourceFile } from '../ts-utils';
 import { findDecoratorPropertyNode } from '../decorator-utils';
 
 export interface ComponentInfo {

--- a/src/migrate-component/index.ts
+++ b/src/migrate-component/index.ts
@@ -1,3 +1,4 @@
+import { dirname, basename } from 'path';
 import {
   Rule,
   SchematicContext,
@@ -15,15 +16,13 @@ import {
 import { InsertChange } from '@schematics/angular/utility/change';
 import { addDeclarationToModule } from '@schematics/angular/utility/ast-utils';
 
-import { dirname, basename } from 'path';
-
-import { Schema as MigrateComponentSchema } from './schema';
-
-import { getSourceFile, addExtension, findRelativeImportPath, getFileContents } from '../utils';
-import { ComponentInfo, parseComponentInfo } from './component-info-utils';
+import { addExtension, findRelativeImportPath, getFileContents } from '../utils';
 import { getNsConfigExtension, Extensions } from '../generate/utils';
-
 import { Schema as ConvertRelativeImportsSchema } from '../convert-relative-imports/schema';
+import { getSourceFile } from '../ts-utils';
+
+import { ComponentInfo, parseComponentInfo } from './component-info-utils';
+import { Schema as MigrateComponentSchema } from './schema';
 
 let extensions: Extensions;
 

--- a/src/migrate-component/index_spec.ts
+++ b/src/migrate-component/index_spec.ts
@@ -8,9 +8,9 @@ import { isInModuleMetadata } from '../test-utils';
 import { Schema as ApplicationOptions } from '../ng-new/shared/schema';
 import { Schema as ModuleOptions } from '../generate/module/schema';
 import { Schema as ComponentOptions } from '../generate/component/schema';
-import { moveToRoot, getSourceFile } from '../utils';
+import { moveToRoot } from '../utils';
+import { findImports, getSourceFile } from '../ts-utils';
 import { Schema as MigrateComponentOptions } from './schema';
-import { findImports } from '../ast-utils';
 
 describe('Migrate component schematic', () => {
     const project = 'some-project';

--- a/src/migrate-module/index.ts
+++ b/src/migrate-module/index.ts
@@ -6,19 +6,18 @@ import {
   schematic,
   SchematicsException
 } from '@angular-devkit/schematics';
-
-import { addExtension, getSourceFile } from '../utils';
-
-import { Schema as MigrateModuleSchema } from './schema';
-import { Schema as ModuleSchema } from '../generate/module/schema';
-import { Schema as MigrateComponentSchema } from '../migrate-component/schema';
-
-import { parseModuleInfo, ModuleInfo } from './module-info-utils';
 import { addProviderToModule } from '@schematics/angular/utility/ast-utils';
 import { InsertChange } from '@schematics/angular/utility/change';
-import { getNsConfigExtension } from '../generate/utils';
 
+import { addExtension } from '../utils';
+import { getSourceFile } from '../ts-utils';
+import { getNsConfigExtension } from '../generate/utils';
+import { parseModuleInfo, ModuleInfo } from './module-info-utils';
+
+import { Schema as ModuleSchema } from '../generate/module/schema';
+import { Schema as MigrateComponentSchema } from '../migrate-component/schema';
 import { Schema as ConvertRelativeImportsSchema } from '../convert-relative-imports/schema';
+import { Schema as MigrateModuleSchema } from './schema';
 
 let nsext: string;
 let moduleInfo: ModuleInfo;

--- a/src/migrate-module/index_spec.ts
+++ b/src/migrate-module/index_spec.ts
@@ -10,9 +10,9 @@ import { Schema as MigrateModuleOptions } from './schema';
 import { Schema as ApplicationOptions } from '../ng-new/shared/schema';
 import { Schema as ComponentOptions } from '../generate/component/schema';
 import { Schema as ModuleOptions } from '../generate/module/schema';
-import { getSourceFile, moveToRoot } from '../utils';
+import { moveToRoot } from '../utils';
 import { isInModuleMetadata } from '../test-utils';
-import { findImports } from '../ast-utils';
+import { findImports, getSourceFile } from '../ts-utils';
 
 describe('Migrate module Schematic', () => {
   const project = 'some-project';

--- a/src/refactor-nsng-modules/index.ts
+++ b/src/refactor-nsng-modules/index.ts
@@ -7,7 +7,7 @@ import {
 import { insertImport } from '../route-utils';
 
 import { Schema } from './schema';
-import { getJsonFile, getSourceFile, removeNode } from '../utils';
+import { getJsonFile, removeNode } from '../utils';
 import {
   collectDeepNodes,
   filterByChildNode,
@@ -18,7 +18,8 @@ import {
   getSymbolsToAddToObject,
   removeImport,
   getDecoratedClass,
-} from '../ast-utils';
+  getSourceFile,
+} from '../ts-utils';
 
 import * as ts from 'typescript';
 import { SchematicsException } from '@angular-devkit/schematics/src/exception/exception';

--- a/src/route-utils.ts
+++ b/src/route-utils.ts
@@ -1,7 +1,7 @@
 import * as ts from 'typescript';
 import { Change, NoopChange } from '@schematics/angular/utility/change';
 import { findNodes } from '@schematics/angular/utility/ast-utils';
-import { insertBeforeFirstOccurence } from './ast-utils';
+import { insertBeforeFirstOccurence } from './ts-utils';
 
 /**
 * Add Import `import { symbolName } from fileName` if the import doesn't exit

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { relative, join, dirname } from 'path';
+import { relative, join } from 'path';
 
 import {
   SchematicsException,
@@ -7,10 +7,8 @@ import {
   move,
 } from '@angular-devkit/schematics';
 import { strings as angularStringUtils } from '@angular-devkit/core';
-import * as ts from 'typescript';
 import { NsConfig } from './models/nsconfig';
 import { UnitTestTree, SchematicTestRunner } from '@angular-devkit/schematics/testing';
-
 
 const PACKAGE_JSON = 'package.json';
 
@@ -42,19 +40,6 @@ export const schematicRunner = new SchematicTestRunner(
   'nativescript-schematics',
   join(__dirname, 'collection.json'),
 );
-
-export const getSourceFile = (host: Tree, path: string): ts.SourceFile => {
-  const buffer = host.read(path);
-  if (!buffer) {
-    throw new SchematicsException(
-      `Could not find file at ${path}. See https://github.com/NativeScript/nativescript-schematics/issues/172.`
-    );
-  }
-  const content = buffer.toString();
-  const source = ts.createSourceFile(path, content, ts.ScriptTarget.Latest, true);
-
-  return source;
-}
 
 export const removeNode = (node: Node, filePath: string, tree: Tree) => {
   const recorder = tree.beginUpdate(filePath);
@@ -284,20 +269,3 @@ function callRuleSync<T extends Tree | UnitTestTree>(
 
   return newTree;
 }
-
-export function parseTsConfigFile(tree: Tree, tsConfigPath: string): ts.ParsedCommandLine {
-  const config = getJsonFile(tree, tsConfigPath);
-  const host: ts.ParseConfigHost = {
-    useCaseSensitiveFileNames: ts.sys.useCaseSensitiveFileNames,
-    readDirectory: ts.sys.readDirectory,
-    fileExists: (file: string) => tree.exists(file),
-    readFile: (file: string) => getFileContents(tree, file)
-  };
-  const basePath = dirname(tsConfigPath);
-
-  const tsConfigObject = ts.parseJsonConfigFileContent(config, host, basePath);
-
-  return tsConfigObject;
-}
-
-


### PR DESCRIPTION
- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA].
- [X] All existing tests are passing: https://github.com/NativeScript/nativescript-schematics/blob/master/CONTRIBUTING.md#running-tests.
- [X] Tests for the changes are included.

## What is the current behavior?
The `utils.ts` module requires `typescript.` This causes all schematics requiring the `utils.ts` to also try to load `typescript` even if it's not needed. The `typescript` module is available when executing schematics in an Angular project because all Angular projects depend on `typecsript`. However, trying to load `typescript` when executing `ng new` will fail unless `typescript` is globally installed.

## What is the new behavior?
The TypeScript helper functions are moved to a separate `ts-utils.ts` file.

Fixes #216.