### PR TITLE
refactor: update to NativeScript 6.0

### DIFF
--- a/src/add-ns/_ns-files/__sourceDir__/package.json
+++ b/src/add-ns/_ns-files/__sourceDir__/package.json
@@ -1,6 +1,7 @@
 {
+  "main": "<%= main %><%= nsext %>.js",
   "android": {
-    "v8Flags": "--expose_gc"
-  },
-  "main": "<%= main %><%= nsext %>.js"
+    "v8Flags": "--expose_gc",
+    "markingMode": "none"
+  }
 }

--- a/src/generate-template/master-detail/_files-nsonly/__name__/__detail__-detail/__detail__-detail.component.ts
+++ b/src/generate-template/master-detail/_files-nsonly/__name__/__detail__-detail/__detail__-detail.component.ts
@@ -5,7 +5,6 @@ import { DataService, Number } from '../data.service';
 
 @Component({
   selector: '<%= prefix %>-details',
-  moduleId: module.id,
   templateUrl: './<%= detail %>-detail.component.html',
 })
 export class <%= detailClassName %>DetailComponent implements OnInit {

--- a/src/generate-template/master-detail/_files-nsonly/__name__/__master__/__master__.component.ts
+++ b/src/generate-template/master-detail/_files-nsonly/__name__/__master__/__master__.component.ts
@@ -4,7 +4,6 @@ import { DataService, Number } from '../data.service';
 
 @Component({
   selector: '<%= prefix %>-<%= master %>',
-  moduleId: module.id,
   templateUrl: './<%= master %>.component.html',
 })
 export class <%= masterClassName %>Component implements OnInit {

--- a/src/generate/component/ast-utils.ts
+++ b/src/generate/component/ast-utils.ts
@@ -3,39 +3,9 @@ import * as ts from 'typescript';
 import { SchematicsException, Tree } from '@angular-devkit/schematics';
 import { classify } from '@angular-devkit/core/src/utils/strings';
 import { buildRelativePath } from '@schematics/angular/utility/find-module';
-import { InsertChange, Change } from '@schematics/angular/utility/change';
+import { InsertChange } from '@schematics/angular/utility/change';
 import { addEntryComponentToModule, addExportToModule, addDeclarationToModule } from '@schematics/angular/utility/ast-utils';
 import { Schema as ComponentOptions } from './schema';
-import { addSymbolToDecoratorMetadata, getSourceFile } from '../../ts-utils';
-
-export const insertModuleId = (tree: Tree, component: string) => {
-  const componentSource = getSourceFile(tree, component);
-  const recorder = tree.beginUpdate(component);
-
-  const metadataChange = addSymbolToComponentMetadata(
-    componentSource, component, 'moduleId', 'module.id');
-
-  metadataChange.forEach((change: InsertChange) =>
-    recorder.insertRight(change.pos, change.toAdd)
-  );
-  tree.commitUpdate(recorder);
-};
-
-function addSymbolToComponentMetadata(
-  source: ts.SourceFile,
-  componentPath: string,
-  metadataField: string,
-  symbolName: string,
-): Change[] {
-  return addSymbolToDecoratorMetadata(
-    source,
-    componentPath,
-    metadataField,
-    symbolName,
-    'Component',
-    '@angular/core'
-  );
-}
 
 export function addDeclarationToNgModule(tree: Tree, options: ComponentOptions, componentPath: string, modulePath: string) {
   const source = readIntoSourceFile(tree, modulePath);

--- a/src/generate/component/index.ts
+++ b/src/generate/component/index.ts
@@ -20,7 +20,7 @@ import { Path, TemplateOptions } from '@angular-devkit/core';
 import { parseName } from '@schematics/angular/utility/parse-name';
 
 import { Extensions, getExtensions, removeNsSchemaOptions, PlatformUse, getPlatformUse, validateGenerateOptions } from '../utils';
-import { addDeclarationToNgModule, insertModuleId } from './ast-utils';
+import { addDeclarationToNgModule } from './ast-utils';
 import { Schema as ComponentOptions } from './schema';
 import { findModule } from './find-module';
 
@@ -83,12 +83,6 @@ export default function (options: ComponentOptions): Rule {
       }
 
       return tree;
-    },
-
-    (tree: Tree) => {
-      if (platformUse.nsOnly) {
-        insertModuleId(tree, componentInfo.classPath);
-      }
     },
 
     (tree: Tree, context: SchematicContext) => {

--- a/src/generate/component/index_spec.ts
+++ b/src/generate/component/index_spec.ts
@@ -40,12 +40,6 @@ describe('Component Schematic', () => {
 
   let appTree: UnitTestTree;
 
-  const hasModuleId = () => {
-    const content = getFileContent(appTree, componentPath);
-    const matcher = isInComponentMetadata(componentClassName, 'moduleId', 'module.id', false);
-    return content.match(matcher);
-  };
-
   const ensureWebTemplate = (tree: UnitTestTree, path: string) => {
     expect(tree.exists(path)).toBeTruthy();
 
@@ -78,8 +72,6 @@ describe('Component Schematic', () => {
       expect(appTree.exists(noExtensionStylesheetPath)).toBeTruthy());
     it('should not create stylesheet with {N} extension', () =>
       expect(appTree.exists(nsStylesheetPath)).toBeFalsy());
-
-    it('should add module id', () => expect(hasModuleId()).toBeTruthy());
 
     it('should declare the component in the root NgModule for {N}', () => {
       const nsModuleContent = getFileContent(appTree, rootModulePath);
@@ -129,8 +121,6 @@ describe('Component Schematic', () => {
       it('should add {N}-specific stylesheet file', () =>
         expect(appTree.exists(nsStylesheetPath)).toBeTruthy());
 
-      it('should add module id', () => expect(hasModuleId()).toBeFalsy());
-
       it('should declare the component in the the root NgModule for web', () => {
         const webModuleContent = getFileContent(appTree, rootModulePath);
         expect(webModuleContent).toMatch(isInModuleMetadata('AppModule', 'declarations', componentClassName, true));
@@ -169,7 +159,6 @@ describe('Component Schematic', () => {
       it('should add {N}-specific markup file', () => ensureNsTemplate(appTree, nsTemplatePath));
       it('should add {N}-specific stylesheet file', () =>
         expect(appTree.exists(nsStylesheetPath)).toBeTruthy());
-      it('should add module id', () => expect(hasModuleId()).toBeFalsy());
 
       it('should not declare the component in the the root NgModule for web', () => {
         const webModuleContent = getFileContent(appTree, rootModulePath);
@@ -191,7 +180,6 @@ describe('Component Schematic', () => {
       });
 
       it('should add web-specific markup file', () => ensureWebTemplate(appTree, webTemplatePath));
-      it('should add module id', () => expect(hasModuleId()).toBeFalsy());
 
       it('should declare the component in the the root NgModule for web', () => {
         const webModuleContent = getFileContent(appTree, rootModulePath);

--- a/src/ng-new/application/_files/__sourcedir__/home/home.component.ts
+++ b/src/ng-new/application/_files/__sourcedir__/home/home.component.ts
@@ -3,8 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: '<%= prefix %>-home',
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.<%= style %>'],
-  moduleId: module.id,
+  styleUrls: ['./home.component.<%= style %>']
 })
 export class HomeComponent {
   title = '<%= name %>';

--- a/src/ng-new/application/_files/__sourcedir__/package.json
+++ b/src/ng-new/application/_files/__sourcedir__/package.json
@@ -1,6 +1,7 @@
 {
+  "main": "main.js",
   "android": {
-    "v8Flags": "--expose_gc"
-  },
-  "main": "main.js"
+    "v8Flags": "--expose_gc",
+    "markingMode": "none"
+  }
 }

--- a/src/ng-new/application/_files/package.json
+++ b/src/ng-new/application/_files/package.json
@@ -18,16 +18,16 @@
     "nativescript-angular": "~8.0.1",<% if(theme) { %>
     "nativescript-theme-core": "~1.0.4",
     <% } %>"reflect-metadata": "~0.1.12",
-    "rxjs": "~6.4.0",
-    "tns-core-modules": "~5.4.0",
+    "rxjs": "~6.5.0",
+    "tns-core-modules": "~6.0.0",
     "zone.js": "~0.9.1"
   },
   "devDependencies": {
     "@angular/cli": "^8.0.3",
     "@angular/compiler-cli": "~8.0.1",
     "@angular-devkit/core": "~8.0.1",
-    "@nativescript/schematics": "~0.6.0",<% if(webpack) { %>
-    "nativescript-dev-webpack": "~0.24.0",
+    "@nativescript/schematics": "~0.7.0",<% if(webpack) { %>
+    "nativescript-dev-webpack": "~1.0.0",
     "@ngtools/webpack": "~8.0.3",
     <% } %>"typescript": "~3.4.3"
   }

--- a/src/ng-new/shared/_files/__sourcedir__/package.json
+++ b/src/ng-new/shared/_files/__sourcedir__/package.json
@@ -1,8 +1,7 @@
 {
-  "android": {
-    "v8Flags": "--expose_gc"
-  },
   "main": "main.tns.js",
-  "name": "migration-ng",
-  "version": "4.1.0"
+  "android": {
+    "v8Flags": "--expose_gc",
+    "markingMode": "none"
+  }
 }

--- a/src/ng-new/shared/_files/package.json
+++ b/src/ng-new/shared/_files/package.json
@@ -31,8 +31,8 @@
     "nativescript-angular": "~8.0.1",<% if(theme) { %>
     "nativescript-theme-core": "~1.0.4",
     <% } %>"reflect-metadata": "~0.1.12",
-    "rxjs": "~6.4.0",
-    "tns-core-modules": "~5.4.0",
+    "rxjs": "~6.5.0",
+    "tns-core-modules": "~6.0.0",
     "zone.js": "~0.9.1"
   },
   "devDependencies": {
@@ -51,7 +51,7 @@
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
-    "nativescript-dev-webpack": "~0.24.0",
+    "nativescript-dev-webpack": "~1.0.0",
     "protractor": "~5.4.0",
     "ts-node": "~7.0.0",
     "tslint": "~5.15.0",

--- a/src/ts-utils.ts
+++ b/src/ts-utils.ts
@@ -1,4 +1,4 @@
-import { getDecoratorMetadata, addImportToModule, addBootstrapToModule, addSymbolToNgModuleMetadata, findNodes } from '@schematics/angular/utility/ast-utils';
+import { addImportToModule, addBootstrapToModule, addSymbolToNgModuleMetadata, findNodes } from '@schematics/angular/utility/ast-utils';
 import { InsertChange, Change } from '@schematics/angular/utility/change';
 import { SchematicsException, Rule, Tree } from '@angular-devkit/schematics';
 import * as ts from 'typescript';
@@ -21,27 +21,6 @@ class RemoveContent implements Node {
   public getEnd() {
     return this.end;
   }
-}
-
-// Almost identical to addSymbolToNgModuleMetadata from @schematics/angular/utility/ast-utils
-// the method can be refactored so that it can be used with custom decorators
-export function addSymbolToDecoratorMetadata(
-  source: ts.SourceFile,
-  componentPath: string,
-  metadataField: string,
-  symbolName: string,
-  decoratorName: string,
-  decoratorPackage: string,
-): Change[] {
-  const nodes = getDecoratorMetadata(source, decoratorName, decoratorPackage);
-  let node: any = nodes[0];  // tslint:disable-line:no-any
-
-  // Find the decorator declaration.
-  if (!node) {
-    return [];
-  }
-
-  return getSymbolsToAddToObject(componentPath, node, metadataField, symbolName);
 }
 
 export function getSymbolsToAddToObject(path: string, node: any, metadataField: string, symbolName: string) {


### PR DESCRIPTION
* refactor: bump template versions to {N} 6.0

* refactor: set `markingMode` to `none`

* refactor: remove `moduleId` from component metadata

{N} 6.0 uses only webpack for building. When building Angular apps with
Webpack,the `module.id` is inserted automatically and we don't need to
set it manually. There's even a loader in `nativescript-dev-webpack` which removes the moduleIds from the source code.

In short, the `moduleId: module.id` is useful only for builds without webpack. NativeScript 6.0 doesn't support such builds. That's why we don't need moduleId in the templates anymore.