### PR TITLE
fix: no-dimension listview in stacklayout warning

### DIFF
--- a/src/add-ns/_sample-files/barcelona/players/players.component__nsext__.html
+++ b/src/add-ns/_sample-files/barcelona/players/players.component__nsext__.html
@@ -1,11 +1,11 @@
 <ActionBar title="Barcelona Players" class="action-bar">
 </ActionBar>
 
-<StackLayout class="page">
+<GridLayout class="page">
   <ListView [items]="players" class="list-group">
     <ng-template let-player="item">
       <Label [nsRouterLink]="['/player', player.id]" [text]="player.name"
       class="list-group-item"></Label>
     </ng-template>
   </ListView>
-</StackLayout>
+</GridLayout>

--- a/src/generate-template/master-detail/_files-nsonly/__name__/__master__/__master__.component.html
+++ b/src/generate-template/master-detail/_files-nsonly/__name__/__master__/__master__.component.html
@@ -1,11 +1,11 @@
 <ActionBar title="<%= masterClassName %>" class="action-bar">
 </ActionBar>
 
-<StackLayout class="page">
+<GridLayout class="page">
   <ListView [items]="numbers" class="list-group">
     <ng-template let-number="item">
       <Label [nsRouterLink]="['/<%= detail %>', number.id]" [text]="number.text"
       class="list-group-item"></Label>
     </ng-template>
   </ListView>
-</StackLayout>
+</GridLayout>

--- a/src/generate-template/master-detail/_files-shared/__name__/__master__/__master__.component__nsext__.html
+++ b/src/generate-template/master-detail/_files-shared/__name__/__master__/__master__.component__nsext__.html
@@ -1,11 +1,11 @@
 <ActionBar title="<%= masterClassName %>" class="action-bar">
 </ActionBar>
 
-<StackLayout class="page">
+<GridLayout class="page">
   <ListView [items]="numbers" class="list-group">
     <ng-template let-number="item">
       <Label [nsRouterLink]="['/<%= detail %>', number.id]" [text]="number.text"
       class="list-group-item"></Label>
     </ng-template>
   </ListView>
-</StackLayout>
+</GridLayout>

--- a/src/ng-new/shared/_sample-files/barcelona/players/players.component.tns.html
+++ b/src/ng-new/shared/_sample-files/barcelona/players/players.component.tns.html
@@ -1,11 +1,11 @@
 <ActionBar title="Barcelona Players" class="action-bar">
 </ActionBar>
 
-<StackLayout class="page">
+<GridLayout class="page">
   <ListView [items]="players" class="list-group">
     <ng-template let-player="item">
       <Label [nsRouterLink]="['/player', player.id]" [text]="player.name"
       class="list-group-item"></Label>
     </ng-template>
   </ListView>
-</StackLayout>
+</GridLayout>


### PR DESCRIPTION
Fix no-dimension listview in stacklayout warning:
```
JS: Avoid using ListView or ScrollView with no explicit height set inside StackLayout. Doing so might results in poor user interface performance and a poor user experience.
```