### PR TITLE
refactor(add-ns): remove `include` property from web tsconfig

### DIFF
--- a/src/add-ns/index.ts
+++ b/src/add-ns/index.ts
@@ -257,7 +257,7 @@ const modifyWebTsconfig = (tree: Tree, context: SchematicContext) => {
 
   const srcDir = projectSettings.sourceRoot;
 
-  // files
+  // add list of entry "files"
   const defaultFiles = [
     `${srcDir}/main.ts`,
     `${srcDir}/polyfills.ts`,
@@ -265,6 +265,10 @@ const modifyWebTsconfig = (tree: Tree, context: SchematicContext) => {
 
   tsConfig.files = tsConfig.files || [];
   tsConfig.files.push(...defaultFiles);
+
+  // remove "include" property
+  // because it overrides "files"
+  delete tsConfig.include;
 
   // paths
   const webPaths = {


### PR DESCRIPTION
The `include` property overrides the `files` property, which is needed
for the AoT compilation.
