### PR TITLE
refactor(add-ns): remove `--bundle` flag from scripts

### DIFF
--- a/src/add-ns/index.ts
+++ b/src/add-ns/index.ts
@@ -214,21 +214,16 @@ const mergeGitIgnore = (tree: Tree, context: SchematicContext) => {
   tree.commitUpdate(recorder);
 };
 
-/**
- * Adds {N} npm run scripts to package.json
- * npm run ios => tns run ios --bundle
- * npm run android => tns run android --bundle
- */
 const addRunScriptsToPackageJson = (tree: Tree, context: SchematicContext) => {
   context.logger.info('Adding NativeScript run scripts to package.json');
 
   const packageJson = getPackageJson(tree);
 
   const scriptsToAdd = {
-    android: 'tns run android --bundle',
-    ios: 'tns run ios --bundle',
-    mobile: 'tns run --bundle',
-    preview: 'tns preview --bundle',
+    android: 'tns run android',
+    ios: 'tns run ios',
+    mobile: 'tns run',
+    preview: 'tns preview',
   };
   packageJson.scripts = {...scriptsToAdd, ...packageJson.scripts};
 

--- a/src/add-ns/index_spec.ts
+++ b/src/add-ns/index_spec.ts
@@ -93,8 +93,8 @@ describe('Add {N} schematic', () => {
             const packageJson = JSON.parse(getFileContent(appTree, packageJsonPath));
             const { scripts } = packageJson;
             expect(scripts).toBeDefined();
-            expect(scripts.android).toEqual('tns run android --bundle');
-            expect(scripts.ios).toEqual('tns run ios --bundle');
+            expect(scripts.android).toEqual('tns run android');
+            expect(scripts.ios).toEqual('tns run ios');
         });
 
         it('should add NativeScript key to the package json', () => {

--- a/src/ng-new/shared/_files/package.json
+++ b/src/ng-new/shared/_files/package.json
@@ -11,10 +11,10 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "android": "tns run android --bundle",
-    "ios": "tns run ios --bundle",
-    "mobile": "tns run --bundle",
-    "preview": "tns preview --bundle"
+    "android": "tns run android",
+    "ios": "tns run ios",
+    "mobile": "tns run",
+    "preview": "tns preview"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
The `bundle` flag is no longer needed with {N} 6.0.