### PR TITLE
fix-next: stop preferring android-specific files over ios-specific files

### DIFF
--- a/src/add-ns/_ns-files/tsconfig__nsext__.json
+++ b/src/add-ns/_ns-files/tsconfig__nsext__.json
@@ -5,8 +5,6 @@
     "moduleResolution": "node",
     "paths": {
       "@src/*": [
-        "<%= sourceDir %>/*.android.ts",
-        "<%= sourceDir %>/*.ios.ts",
         "<%= sourceDir %>/*.tns.ts",
         "<%= sourceDir %>/*.ts"
       ]

--- a/src/add-ns/index_spec.ts
+++ b/src/add-ns/index_spec.ts
@@ -144,8 +144,6 @@ describe('Add {N} schematic', () => {
             expect(paths['@src/*']).toBeDefined();
 
             const maps = paths['@src/*'];
-            expect(maps).toContain('src/*.ios.ts');
-            expect(maps).toContain('src/*.android.ts');
             expect(maps).toContain('src/*.tns.ts');
             expect(maps).toContain('src/*.ts');
         });

--- a/src/ng-new/shared/_files/tsconfig.tns.json
+++ b/src/ng-new/shared/_files/tsconfig.tns.json
@@ -5,8 +5,6 @@
     "moduleResolution": "node",
     "paths": {
       "@src/*": [
-        "<%= sourcedir %>/*.android.ts",
-        "<%= sourcedir %>/*.ios.ts",
         "<%= sourcedir %>/*.tns.ts",
         "<%= sourcedir %>/*.ts"
       ]


### PR DESCRIPTION
In the current prerelease version, `*.android.ts` files are preferred over `*.ios.ts` files even when
building for iOS. To reproduce execute:
```
npm i @nativescript/schematics@0.6.1-2019-08-05-173433-01
ng new --shared --collection=@nativescript/schematics shared-project
cd shared-project/src/app

echo "console.log('ANDROID');" > print.android.ts
echo "console.log('IOS');" > print.ios.ts

echo "import '@src/app/print';" >> app.module.ts

tns run ios
```

As a result you will see `ANDROID` printed on the console, meaning that
the Android-specific file was imported even though we built the
application for iOS.
This behaviour is caused by the configuration of the `"paths"` property in
`tsconfig.tns.json`, which tells the TS compiler to look for
`*.android.ts` files first:

```
"compilerOptions": {
  "baseUrl": ".",
  "paths": {
    "@src/*": [
      "src/*.android.ts",
      "src/*.ios.ts",
      "src/*.tns.ts",
      "src/*.ts"
    ]
  }
}
```

This PR removes the `*.android.ts` and `*.ios.ts` lines from the
configuration, delegating the `android` and `ios` file resolution to webpack.