### PR TITLE
fix: make `@schematics/angular` a `devDependency` and update to Angular 8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "@angular-devkit/core": "~8.0.0",
     "@angular-devkit/schematics": "~8.0.0",
     "@nativescript/tslint-rules": "~0.0.3",
-    "@phenomnomnominal/tsquery": "^3.0.0",
-    "@schematics/angular": "~8.0.0"
+    "@phenomnomnominal/tsquery": "^3.0.0"
   },
   "devDependencies": {
+    "@schematics/angular": "~8.0.0",
     "@types/jasmine": "^2.6.0",
     "@types/node": "^8.0.31",
     "conventional-changelog-cli": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -17,20 +17,20 @@
   },
   "schematics": "./src/collection.json",
   "dependencies": {
-    "@angular-devkit/core": "~8.0.0",
-    "@angular-devkit/schematics": "~8.0.0",
+    "@angular-devkit/core": "~8.2.0",
+    "@angular-devkit/schematics": "~8.2.0",
     "@nativescript/tslint-rules": "~0.0.3",
     "@phenomnomnominal/tsquery": "^3.0.0"
   },
   "devDependencies": {
-    "@schematics/angular": "~8.0.0",
+    "@schematics/angular": "~8.2.0",
     "@types/jasmine": "^2.6.0",
     "@types/node": "^8.0.31",
     "conventional-changelog-cli": "^2.0.1",
     "jasmine": "^2.8.0",
     "jasmine-spec-reporter": "^4.2.1",
     "tslint": "^5.18.0",
-    "typescript": "3.4.5"
+    "typescript": "3.5.3"
   },
   "repository": {
     "type": "git",

--- a/src/ng-new/application/_files/package.json
+++ b/src/ng-new/application/_files/package.json
@@ -23,7 +23,7 @@
     "zone.js": "~0.9.1"
   },
   "devDependencies": {
-    "@angular/cli": "^8.0.3",
+    "@angular/cli": "~8.0.3",
     "@angular/compiler-cli": "~8.0.1",
     "@angular-devkit/core": "~8.0.1",
     "@nativescript/schematics": "~0.7.0",<% if(webpack) { %>


### PR DESCRIPTION
The `@nativescript/schematics` package uses TypeScript utility functions from `@schematics/angular`. The utility functions return ASTs generated from the source code. After that these ASTs are used by other functions in `@nativescript/schematics`.
`@nativescript/schematics` depends on the version of TypeScript used in the project, whereas `@schematics/angular` has its own dependency on TypeScript. If the versions of the two TypeScript packages don't match, we end up comparing ASTs generated from different TS versions which usually results in an error.
This PR removes the dependency of `@schematics/angular` from the `@nativescript/schematics`. That way, the version in the user's project will be used instead. We rely on the assumption that the project will have matching versions of `@schematics/angular` and TypeScript.