### PR TITLE
fix: use typescript from @schematics/angular

### DIFF
--- a/src/angular-project-parser.ts
+++ b/src/angular-project-parser.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 import { basename } from 'path';
 import { Tree, SchematicsException } from '@angular-devkit/schematics';
 import { getWorkspace } from '@schematics/angular/utility/config';

--- a/src/convert-relative-imports/index.ts
+++ b/src/convert-relative-imports/index.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 import { IRule, Replacement } from 'tslint';
 import { tsquery } from '@phenomnomnominal/tsquery';
 import { Tree, SchematicContext, isContentAction } from '@angular-devkit/schematics';

--- a/src/decorator-utils.ts
+++ b/src/decorator-utils.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 import { Tree } from '@angular-devkit/schematics';
 
 import { findNode, findMatchingNodes, findImportPath, getSourceFile } from './ts-utils';

--- a/src/generate/component/ast-utils.ts
+++ b/src/generate/component/ast-utils.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 
 import { SchematicsException, Tree } from '@angular-devkit/schematics';
 import { classify } from '@angular-devkit/core/src/utils/strings';

--- a/src/mapped-imports-rule-utils.ts
+++ b/src/mapped-imports-rule-utils.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 import {
     PreferMappedImportsRule,
     RuleArgs,

--- a/src/migrate-component/component-info-utils.ts
+++ b/src/migrate-component/component-info-utils.ts
@@ -3,7 +3,7 @@ import { Schema as MigrateComponentSchema } from './schema';
 import { dasherize, classify } from '@angular-devkit/core/src/utils/strings';
 import { SchematicsException, Tree, SchematicContext } from '@angular-devkit/schematics';
 import { join, dirname } from 'path';
-import * as ts from 'typescript';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 
 import { AngularProjectSettings, getAngularProjectSettings } from '../angular-project-parser';
 import { findImportPath, findMatchingNodes, getSourceFile } from '../ts-utils';

--- a/src/refactor-nsng-modules/index.ts
+++ b/src/refactor-nsng-modules/index.ts
@@ -21,7 +21,7 @@ import {
   getSourceFile,
 } from '../ts-utils';
 
-import * as ts from 'typescript';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 import { SchematicsException } from '@angular-devkit/schematics/src/exception/exception';
 import { InsertChange } from '@schematics/angular/utility/change';
 

--- a/src/route-utils.ts
+++ b/src/route-utils.ts
@@ -1,4 +1,4 @@
-import * as ts from 'typescript';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 import { Change, NoopChange } from '@schematics/angular/utility/change';
 import { findNodes } from '@schematics/angular/utility/ast-utils';
 import { insertBeforeFirstOccurence } from './ts-utils';

--- a/src/ts-utils.ts
+++ b/src/ts-utils.ts
@@ -8,7 +8,7 @@ import {
 } from '@schematics/angular/utility/ast-utils';
 import { InsertChange, Change } from '@schematics/angular/utility/change';
 import { SchematicsException, Rule, Tree } from '@angular-devkit/schematics';
-import * as ts from 'typescript';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
 
 import { toComponentClassName, Node, removeNode, getFileContents, getJsonFile } from './utils';
 


### PR DESCRIPTION
The `@nativescript/schematics` package uses TypeScript utility functions from `@schematics/angular`. The utility functions return ASTs generated from the source code. After that these ASTs are used by other functions in `@nativescript/schematics`.
`@nativescript/schematics` depends on the version of TypeScript used in the project, whereas `@schematics/angular` embeds its [own version of `typescript`](angular/angular-cli:packages/schematics/angular/utility/ast-utils.ts@master#L8). If the versions of the two TypeScript packages don't match, we end up comparing ASTs generated from different TS versions which usually results in an error. Currently, we rely on the assumption that the project will have matching versions of `@schematics/angular` and `TypeScript`.

With this PR, the code using utilities from `@schematics/angular` now imports `typescript` from `@schematics/angular` guaranteeing the same instance of the TypeScript library will be used.