### PR TITLE
fix: extends correctly tsconfig.json from tsconfig.spec.json

### DIFF
--- a/src/add-ns/index_spec.ts
+++ b/src/add-ns/index_spec.ts
@@ -148,6 +148,18 @@ describe('Add {N} schematic', () => {
             expect(maps).toContain('src/*.ts');
         });
 
+        it('should create the tsconfig.spec.json (web) with files', () => {
+            const specTsConfigPath = '/tsconfig.spec.json';
+            expect(appTree.files).toContain(specTsConfigPath);
+
+            const specTsConfig = JSON.parse(getFileContent(appTree, specTsConfigPath));
+            const files = specTsConfig.files;
+
+            expect(files).toBeDefined();
+            expect(files.includes('src/test.ts')).toBeTruthy();
+            expect(files.includes('src/polyfills.ts')).toBeTruthy();
+        });
+
         it('should modify the base tsconfig.json to include path mappings', () => {
             const baseTsConfigPath = '/tsconfig.json';
             expect(appTree.files).toContain(baseTsConfigPath);

--- a/src/ng-new/shared/_files/tsconfig.spec.json
+++ b/src/ng-new/shared/_files/tsconfig.spec.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../out-tsc/spec",
     "module": "commonjs",
@@ -9,8 +9,8 @@
     ]
   },
   "files": [
-    "test.ts",
-    "polyfills.ts"
+    "<%= sourcedir %>/test.ts",
+    "<%= sourcedir %>/polyfills.ts"
   ],
   "include": [
     "**/*.spec.ts",

--- a/src/ng-new/shared/index_spec.ts
+++ b/src/ng-new/shared/index_spec.ts
@@ -27,6 +27,7 @@ describe('Shared Application Schematic', () => {
     expect(files).toContain('/foo/.gitignore');
     expect(files).toContain('/foo/package.json');
     expect(files).toContain('/foo/tsconfig.tns.json');
+    expect(files).toContain('/foo/tsconfig.spec.json');
 
     expect(files).toContain('/foo/src/package.json');
     expect(files).toContain('/foo/src/main.tns.ts');


### PR DESCRIPTION
Currently when new code shared app is created, `tsconfig.spec.json` is created with incorrect content. It is looking for one directory up for its base `tsconfig.json` file. Actually both `tsconfig.spec.json` and `tsconfig.json` files are at the root level of the application.

Rel to: https://github.com/NativeScript/nativescript-schematics/issues/243

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-schematics/blob/master/CONTRIBUTING.md#running-tests.
- [ ] Tests for the changes are included.

## What is the current behavior?
`ng test` command doesn't work for code shared applications

## What is the new behavior?
`ng test` works for code shared applications

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla
