### PR TITLE
fix: stop using filter in module generation schematic

### DIFF
--- a/src/collection.json
+++ b/src/collection.json
@@ -37,6 +37,13 @@
         "schema": "./generate/module/schema.json"
     },
 
+
+    "common-module": {
+        "factory": "./generate/common-module",
+        "description": "Generate a common NgModule",
+        "schema": "./generate/common-module/schema.json"
+    },
+
     "app-resources": {
         "factory": "./app-resources",
         "description": "Create App Resources",
@@ -108,6 +115,7 @@
       "factory": "./migrate-component",
       "schema": "./migrate-component/schema.json"
     },
+
     "migrate-module": {
       "aliases": [ "mg" ],
       "description": "Converts a module into a code sharing module",

--- a/src/generate/common-module/_files/__name__.common.ts
+++ b/src/generate/common-module/_files/__name__.common.ts
@@ -1,0 +1,10 @@
+import { Routes } from '@angular/router';
+
+export const componentDeclarations: any[] = [
+];
+
+export const providerDeclarations: any[] = [
+];
+
+export const routes: Routes = [
+];

--- a/src/generate/common-module/index.ts
+++ b/src/generate/common-module/index.ts
@@ -1,0 +1,21 @@
+import {
+  Rule,
+  mergeWith,
+  apply,
+  url,
+  template,
+  move,
+} from '@angular-devkit/schematics';
+
+import { Schema as CommonModuleOptions } from './schema';
+
+export default function(options: CommonModuleOptions): Rule {
+  const { name, path } = options;
+
+  return mergeWith(
+    apply(url('./_files'), [
+      template({ name }),
+      move(path),
+    ]),
+  );
+}

--- a/src/generate/common-module/schema.d.ts
+++ b/src/generate/common-module/schema.d.ts
@@ -1,0 +1,10 @@
+export interface Schema {
+  /**
+   * The name of the module.
+   */
+  name: string;
+  /**
+   * The path to create the module.
+   */
+  path: string;
+}

--- a/src/generate/common-module/schema.json
+++ b/src/generate/common-module/schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "SchematicsNativeScriptAngularCommonModule",
+  "title": "NativeScript Angular Common Module Options Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name of the module."
+    },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "description": "The path to create the module."
+    }
+  },
+  "required": [],
+  "additionalProperties": false
+}

--- a/src/generate/module/index_spec.ts
+++ b/src/generate/module/index_spec.ts
@@ -226,7 +226,7 @@ describe('Module Schematic', () => {
         expect(tree.exists(webModulePath)).toBeTruthy();
       });
 
-      it('should not create a common file', async () => {
+      it('should create a common file', async () => {
         const options = { ...nsWebOptions };
         const tree = await schematicRunner.runSchematicAsync('module', options, appTree).toPromise();
 

--- a/src/migrate-module/_ns-files/__name@dasherize__.module__nsext__.ts
+++ b/src/migrate-module/_ns-files/__name@dasherize__.module__nsext__.ts
@@ -1,0 +1,16 @@
+import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
+import { NativeScriptCommonModule } from 'nativescript-angular/common';
+
+@NgModule({
+  imports: [
+    NativeScriptCommonModule
+  ],
+  declarations: [
+  ],
+  providers: [
+  ],
+  schemas: [
+    NO_ERRORS_SCHEMA
+  ]
+})
+export class <%= classify(name) %>Module { }


### PR DESCRIPTION
Let's say that you execute the command:
```
ng g migrate-module about
```

**Before this PR:**

- The `migrate-module` schematic uses the `module` schematic to generate a NgModule with `name='about'`;
- the `module` schematic filters out the files that end with `about.module.ts` - this is done because otherwise the we'll get a merge conflict;
- the `module` schematic uses the external `@schematics/angular module` schematic to generate `about.module.ts`;
- the `migrate-module` schematic renames `about.module.ts` to `about.module.tns.ts`.

Unfortunately, the `filter` function visits all files in `node_modules` and `platforms` and slows down the execution of the `module` schematic significantly. 

**With this PR:**

- The `migrate-module` schematic generates a NgModule file from a template instead of relying on the `module` schematic.
- The `module` schematic doesn't use `filter` anymore, which speeds up the execution of the command.

fixes #185, #203