### PR TITLE
fix: don't check the `.d.ts` files from `node_modules`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/schematics",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Schematics for NativeScript Angular apps.",
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/src/ng-new/application/_files/tsconfig.json
+++ b/src/ng-new/application/_files/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "es5",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "skipLibCheck": true,
     "noEmitHelpers": true,
     "noEmitOnError": true,
     "lib": [

--- a/src/ng-new/shared/_files/tsconfig.json
+++ b/src/ng-new/shared/_files/tsconfig.json
@@ -7,6 +7,7 @@
       "moduleResolution": "node",
       "emitDecoratorMetadata": true,
       "experimentalDecorators": true,
+      "skipLibCheck": true,
       "target": "es5",
       "typeRoots": [
           "node_modules/@types"


### PR DESCRIPTION
`Cannot find type definition file for 'jasmine/v2'` error is thrown when a new code shared application is created. It seems the issue comes [from this commit inside jasmine repo](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38412/files#diff-704f3d6b17350ee2426b25280154df4f).  Adding `skipLibCheck: true` to `tsconfig.json`  will skip the checks of `.d.ts` files inside `node_modules`. This will also improve the performance of typescript compilation with a lot of deps and files to process.

Rel to: https://github.com/NativeScript/nativescript-schematics/issues/249

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-schematics/blob/master/CONTRIBUTING.md#running-tests.
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla
