### PR TITLE
fix: convert web application to code-shared when using scss or less styles

### DIFF
--- a/src/angular-project-parser.ts
+++ b/src/angular-project-parser.ts
@@ -166,7 +166,7 @@ function parseAngularConfig(tree, projectName: string) {
   return { targets, project };
 }
 
-function getProjectObject(tree: Tree, projectName: string) {
+export function getProjectObject(tree: Tree, projectName: string) {
   const workspace = getWorkspace(tree);
   const project = getProject(workspace, projectName);
   if (!project) {

--- a/src/generate/component/index.ts
+++ b/src/generate/component/index.ts
@@ -17,6 +17,7 @@ import {
 
 import { dasherize } from '@angular-devkit/core/src/utils/strings';
 import { parseName } from '@schematics/angular/utility/parse-name';
+import { getProjectObject } from '../../angular-project-parser';
 
 import {
   Extensions,
@@ -51,6 +52,13 @@ export default function(options: ComponentOptions): Rule {
 
       if (platformUse.nsOnly && options.spec !== true) {
         options.spec = false;
+      }
+
+      const projectObject = getProjectObject(tree, options.project);
+      const styleext = (projectObject && projectObject.schematics && projectObject.schematics['@schematics/angular:component']
+        && projectObject.schematics['@schematics/angular:component'].style);
+      if (styleext) {
+        options.styleext = styleext;
       }
 
       validateGenerateOptions(platformUse, options);


### PR DESCRIPTION
The  `ng add @nativescript/schematics` works only when using `css` styles within the web application. This PR gets the styles from `angular.json` and sets them to the `styleext` option. This way, the styles are respected when adding the auto-generated component.

Rel to: https://github.com/NativeScript/nativescript-schematics/issues/238

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-schematics/blob/master/CONTRIBUTING.md#running-tests.
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla
