### PR TITLE
Update ng-add and ng-new to {N} 6.1

### DIFF
--- a/src/add-ns/index.ts
+++ b/src/add-ns/index.ts
@@ -362,15 +362,15 @@ const addDependencies = () => (tree: Tree, context: SchematicContext) => {
 
   // @UPGRADE: Update all versions whenever {N} version updates
   const depsToAdd = {
-    'nativescript-angular': '~8.0.1',
+    'nativescript-angular': '~8.2.0',
     'nativescript-theme-core': '~1.0.4',
     'reflect-metadata': '~0.1.12',
-    'tns-core-modules': '~6.0.0',
+    'tns-core-modules': '~6.1.0',
   };
   packageJson.dependencies = {...depsToAdd, ...packageJson.dependencies};
 
   const devDepsToAdd = {
-    'nativescript-dev-webpack': '~1.0.0',
+    'nativescript-dev-webpack': '~1.2.0',
     '@nativescript/schematics': '~0.7.0',
     '@nativescript/tslint-rules': '~0.0.2',
   };

--- a/src/ng-new/application/_files/package.json
+++ b/src/ng-new/application/_files/package.json
@@ -6,29 +6,29 @@
     "id": "org.nativescript.<%= utils.sanitize(name) %>"
   },
   "dependencies": {
-    "@angular/animations": "~8.0.1",
-    "@angular/common": "~8.0.1",
-    "@angular/compiler": "~8.0.1",
-    "@angular/core": "~8.0.1",
-    "@angular/forms": "~8.0.1",
+    "@angular/animations": "~8.2.0",
+    "@angular/common": "~8.2.0",
+    "@angular/compiler": "~8.2.0",
+    "@angular/core": "~8.2.0",
+    "@angular/forms": "~8.2.0",
     "@angular/http": "~8.0.0-beta.10",
-    "@angular/platform-browser": "~8.0.1",
-    "@angular/platform-browser-dynamic": "~8.0.1",
-    "@angular/router": "~8.0.1",
-    "nativescript-angular": "~8.0.1",<% if(theme) { %>
+    "@angular/platform-browser": "~8.2.0",
+    "@angular/platform-browser-dynamic": "~8.2.0",
+    "@angular/router": "~8.2.0",
+    "nativescript-angular": "~8.2.0",<% if(theme) { %>
     "nativescript-theme-core": "~1.0.4",
     <% } %>"reflect-metadata": "~0.1.12",
-    "rxjs": "~6.5.0",
-    "tns-core-modules": "~6.0.0",
+    "rxjs": "~6.4.0",
+    "tns-core-modules": "~6.1.0",
     "zone.js": "~0.9.1"
   },
   "devDependencies": {
-    "@angular/cli": "~8.0.3",
-    "@angular/compiler-cli": "~8.0.1",
-    "@angular-devkit/core": "~8.0.1",
+    "@angular/cli": "~8.3.0",
+    "@angular/compiler-cli": "~8.2.0",
+    "@angular-devkit/core": "~8.2.0",
     "@nativescript/schematics": "~0.7.0",<% if(webpack) { %>
-    "nativescript-dev-webpack": "~1.0.0",
-    "@ngtools/webpack": "~8.0.3",
-    <% } %>"typescript": "~3.4.3"
+    "nativescript-dev-webpack": "~1.2.0",
+    "@ngtools/webpack": "~8.2.0",
+    <% } %>"typescript": "~3.5.3"
   }
 }

--- a/src/ng-new/shared/_files/package.json
+++ b/src/ng-new/shared/_files/package.json
@@ -18,29 +18,29 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "~8.0.1",
-    "@angular/common": "~8.0.1",
-    "@angular/compiler": "~8.0.1",
-    "@angular/core": "~8.0.1",
-    "@angular/forms": "~8.0.1",
+    "@angular/animations": "~8.2.0",
+    "@angular/common": "~8.2.0",
+    "@angular/compiler": "~8.2.0",
+    "@angular/core": "~8.2.0",
+    "@angular/forms": "~8.2.0",
     "@angular/http": "~8.0.0-beta.10",
-    "@angular/platform-browser": "~8.0.1",
-    "@angular/platform-browser-dynamic": "~8.0.1",
-    "@angular/router": "~8.0.1",
-    "core-js": "^2.5.4",
-    "nativescript-angular": "~8.0.1",<% if(theme) { %>
+    "@angular/platform-browser": "~8.2.0",
+    "@angular/platform-browser-dynamic": "~8.2.0",
+    "@angular/router": "~8.2.0",
+    "core-js": "^2.6.9",
+    "nativescript-angular": "~8.2.0",<% if(theme) { %>
     "nativescript-theme-core": "~1.0.4",
     <% } %>"reflect-metadata": "~0.1.12",
-    "rxjs": "~6.5.0",
-    "tns-core-modules": "~6.0.0",
+    "rxjs": "~6.4.0",
+    "tns-core-modules": "~6.1.0",
     "zone.js": "~0.9.1"
   },
   "devDependencies": {
-    "@angular/cli": "~8.0.3",
-    "@angular/compiler-cli": "~8.0.1",
-    "@angular-devkit/build-angular": "~0.800.0",
+    "@angular/cli": "~8.3.0",
+    "@angular/compiler-cli": "~8.2.0",
+    "@angular-devkit/build-angular": "~0.803.0",
     "@nativescript/schematics": "~0.7.0",
-    "@nativescript/tslint-rules": "~0.0.2",
+    "@nativescript/tslint-rules": "~0.0.4",
     "@types/jasmine": "~3.3.8",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "~8.9.4",
@@ -52,10 +52,10 @@
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-jasmine": "~2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
-    "nativescript-dev-webpack": "~1.0.0",
+    "nativescript-dev-webpack": "~1.2.0",
     "protractor": "~5.4.0",
     "ts-node": "~7.0.0",
     "tslint": "~5.15.0",
-    "typescript": "~3.4.3"
+    "typescript": "~3.5.3"
   }
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-schematics/blob/master/CONTRIBUTING.md#running-tests.
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
Currently, new-add and ng-new doesn't use the latest config required by `tns preview`. 
For example `tns preview` doesn't load `styles.css`

## What is the new behavior?
<!-- Describe the changes. -->
Uses the correct dependencies required by {N} 6.1

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla
