### PR TITLE
fix: update version of `@nativescript/schematics` to `0.8.0` inside templates

### DIFF
--- a/src/add-ns/index.ts
+++ b/src/add-ns/index.ts
@@ -372,7 +372,7 @@ const addDependencies = () => (tree: Tree, context: SchematicContext) => {
 
   const devDepsToAdd = {
     'nativescript-dev-webpack': '~1.3.0',
-    '@nativescript/schematics': '~0.7.0',
+    '@nativescript/schematics': '~0.8.0',
     '@nativescript/tslint-rules': '~0.0.2',
   };
   packageJson.devDependencies = {...devDepsToAdd, ...packageJson.devDependencies};

--- a/src/ng-new/application/_files/package.json
+++ b/src/ng-new/application/_files/package.json
@@ -27,7 +27,7 @@
     "@angular/cli": "~8.3.0",
     "@angular/compiler-cli": "~8.2.0",
     "@angular-devkit/core": "~8.2.0",
-    "@nativescript/schematics": "~0.7.0",<% if(webpack) { %>
+    "@nativescript/schematics": "~0.8.0",<% if(webpack) { %>
     "nativescript-dev-webpack": "~1.3.0",
     "@ngtools/webpack": "~8.2.0",
     <% } %>"typescript": "~3.5.3"

--- a/src/ng-new/shared/_files/package.json
+++ b/src/ng-new/shared/_files/package.json
@@ -40,7 +40,7 @@
     "@angular/cli": "~8.3.0",
     "@angular/compiler-cli": "~8.2.0",
     "@angular-devkit/build-angular": "~0.803.0",
-    "@nativescript/schematics": "~0.7.0",
+    "@nativescript/schematics": "~0.8.0",
     "@nativescript/tslint-rules": "~0.0.4",
     "@types/jasmine": "~3.3.8",
     "@types/jasminewd2": "~2.0.3",


### PR DESCRIPTION
Currently `@nativescript/schematics@~0.7.0` is added as dependency to the project, so when a new project is created an old version of `@nativescript/schematics` is installed. Updating the version to `@8.0.0` will lead to an another problem that a version that is still not published to `npm` will be referenced within the project. In such a situation, the project should be created using `--skip-install` flag e.g `ng new --collection=@nativescript/schematics myApp --shared --skip-install`, after that the next version should be installed in the project before executing `tns run`.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-schematics/blob/master/CONTRIBUTING.md#running-tests.
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla
