### PR TITLE
fix: fix the theme when app is created with scss styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nativescript/schematics",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "Schematics for NativeScript Angular apps.",
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/src/add-ns/index.ts
+++ b/src/add-ns/index.ts
@@ -372,7 +372,7 @@ const addDependencies = () => (tree: Tree, context: SchematicContext) => {
 
   const devDepsToAdd = {
     'nativescript-dev-webpack': '~1.3.0',
-    '@nativescript/schematics': '~0.8.0',
+    '@nativescript/schematics': '~1.0.0',
     '@nativescript/tslint-rules': '~0.0.2',
   };
   packageJson.devDependencies = {...devDepsToAdd, ...packageJson.devDependencies};

--- a/src/ng-new/application/_files/package.json
+++ b/src/ng-new/application/_files/package.json
@@ -27,7 +27,7 @@
     "@angular/cli": "~8.3.0",
     "@angular/compiler-cli": "~8.2.0",
     "@angular-devkit/core": "~8.2.0",
-    "@nativescript/schematics": "~0.8.0",<% if(webpack) { %>
+    "@nativescript/schematics": "~1.0.0",<% if(webpack) { %>
     "nativescript-dev-webpack": "~1.3.0",
     "@ngtools/webpack": "~8.2.0",
     <% } %>"typescript": "~3.5.3"

--- a/src/ng-new/shared/_files/package.json
+++ b/src/ng-new/shared/_files/package.json
@@ -40,7 +40,7 @@
     "@angular/cli": "~8.3.0",
     "@angular/compiler-cli": "~8.2.0",
     "@angular-devkit/build-angular": "~0.803.0",
-    "@nativescript/schematics": "~0.8.0",
+    "@nativescript/schematics": "~1.0.0",
     "@nativescript/tslint-rules": "~0.0.4",
     "@types/jasmine": "~3.3.8",
     "@types/jasminewd2": "~2.0.3",

--- a/src/styling/_scss-files/_app-common.scss
+++ b/src/styling/_scss-files/_app-common.scss
@@ -1,2 +1,21 @@
+@import "~@nativescript/theme/core";
+@import "~@nativescript/theme/blue";
+
 // Place any CSS rules you want to apply on both iOS and Android here.
 // This is where the vast majority of your CSS code goes.
+
+// Font icon class
+.fab {
+    font-family: "Font Awesome 5 Brands", "fa-brands-400";
+    font-weight: 400;
+}
+
+.fas {
+    font-family: "Font Awesome 5 Free", "fa-solid-900";
+    font-weight: 900;
+}
+
+.far {
+    font-family: "Font Awesome 5 Free", "fa-regular-400";
+    font-weight: 400;
+}


### PR DESCRIPTION
When the application is created with `scss` styles, the theme is not applied due to the missing styles in `app.common` file.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-schematics/blob/master/CONTRIBUTING.md#running-tests.
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla
