### PR TITLE
fix: remove `@angular/http` dependency from blueprints for Angular 9 …

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,12 @@
     "lint": "tslint --project ./tsconfig.json -c ./tslint.json 'src/**/*.ts'",
     "lint:fix": "tslint --project ./tsconfig.json -c ./tslint.json 'src/**/*.ts' --fix"
   },
+  "ng-add": {
+    "save": "devDependencies"
+  },
+  "ng-new": {
+    "save": "devDependencies"
+  },
   "schematics": "./src/collection.json",
   "dependencies": {
     "@angular-devkit/core": "~9.1.0",

--- a/src/add-ns/index.ts
+++ b/src/add-ns/index.ts
@@ -374,7 +374,6 @@ const addDependencies = () => (tree: Tree, context: SchematicContext) => {
 
   const devDepsToAdd = {
     'nativescript-dev-webpack': '~1.5.0',
-    '@nativescript/schematics': '~2.0.0',
     '@nativescript/tslint-rules': '~0.0.5',
   };
   packageJson.devDependencies = {...devDepsToAdd, ...packageJson.devDependencies};

--- a/src/add-ns/index_spec.ts
+++ b/src/add-ns/index_spec.ts
@@ -84,7 +84,6 @@ describe('Add {N} schematic', () => {
             expect(dependencies['reflect-metadata']).toBeDefined();
 
             expect(devDependencies['nativescript-dev-webpack']).toBeDefined();
-            expect(devDependencies['@nativescript/schematics']).toBeDefined();
             expect(devDependencies['@nativescript/tslint-rules']).toBeDefined();
         });
 

--- a/src/ng-new/application/_files/package.json
+++ b/src/ng-new/application/_files/package.json
@@ -11,7 +11,6 @@
     "@angular/compiler": "~9.1.0",
     "@angular/core": "~9.1.0",
     "@angular/forms": "~9.1.0",
-    "@angular/http": "~9.1.0",
     "@angular/platform-browser": "~9.1.0",
     "@angular/platform-browser-dynamic": "~9.1.0",
     "@angular/router": "~9.1.0",

--- a/src/ng-new/application/_files/package.json
+++ b/src/ng-new/application/_files/package.json
@@ -25,8 +25,7 @@
   "devDependencies": {
     "@angular/cli": "~9.1.0",
     "@angular/compiler-cli": "~9.1.0",
-    "@angular-devkit/core": "~9.1.0",
-    "@nativescript/schematics": "~2.0.0",<% if(webpack) { %>
+    "@angular-devkit/core": "~9.1.0",<% if(webpack) { %>
     "nativescript-dev-webpack": "~1.5.0",
     "@ngtools/webpack": "~9.1.0",
     <% } %>"typescript": "~3.8.3"

--- a/src/ng-new/shared/_files/package.json
+++ b/src/ng-new/shared/_files/package.json
@@ -39,7 +39,6 @@
     "@angular/cli": "~9.1.0",
     "@angular/compiler-cli": "~9.1.0",
     "@angular-devkit/build-angular": "~0.901.0",
-    "@nativescript/schematics": "~2.0.0",
     "@nativescript/tslint-rules": "~0.0.5",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",

--- a/src/ng-new/shared/_files/package.json
+++ b/src/ng-new/shared/_files/package.json
@@ -23,7 +23,6 @@
     "@angular/compiler": "~9.1.0",
     "@angular/core": "~9.1.0",
     "@angular/forms": "~9.1.0",
-    "@angular/http": "~9.1.0",
     "@angular/platform-browser": "~9.1.0",
     "@angular/platform-browser-dynamic": "~9.1.0",
     "@angular/router": "~9.1.0",


### PR DESCRIPTION
…based setup

fixes: #278

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-schematics/blob/master/CONTRIBUTING.md#running-tests.
- [ ] Tests for the changes are included.

## What is the current behavior?
Currently `@angular/http` is added as a dependency but it doesn't longer exist

## What is the new behavior?
The dependency is not added anymore

closes #278

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->


[CLA]: http://www.nativescript.org/cla
