### PR TITLE
fix(angular): update typescript to version 4 for ng new

### DIFF
--- a/src/ng-new/shared/_files/package.json
+++ b/src/ng-new/shared/_files/package.json
@@ -57,6 +57,6 @@
     "protractor": "~5.4.3",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
-    "typescript": "~3.9.0"
+    "typescript": "~4.0.0"
   }
 }


### PR DESCRIPTION


<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-schematics/blob/master/CONTRIBUTING.md#running-tests.
- [ ] Tests for the changes are included.

## What is the current behavior?
After creating a new project, when creating a component with 
```
ng new -c=@nativescript/schematics project-name --shared
ng g component bla
```
an error occurs:
```
Cannot read property 'kind' of undefined
```

## What is the new behavior?
No error occurs

Fixes/Implements/Closes #302

[CLA]: http://www.nativescript.org/cla
