### PR TITLE
fix: CLI code generation in ng11.1+ NS-only projects

### DIFF
--- a/adding-angular-CLI-to-NativeScript.md
+++ b/adding-angular-CLI-to-NativeScript.md
@@ -15,7 +15,12 @@
       "root": "",
       "sourceRoot": ".",
        "projectType": "application",
-       "prefix": "app"
+       "prefix": "app",
+       "schematics": {
+        "@schematics/angular:component": {
+          "style": "scss"
+        }
+       }
     }
   },
   "defaultProject": "my-project-name"

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "@angular-devkit/schematics": "~11.0.0",
     "@nativescript/tslint-rules": "~0.0.5",
     "@phenomnomnominal/tsquery": "^4.1.0",
+    "@schematics/angular": "~11.0.0",
     "strip-json-comments": "~3.1.1"
   },
   "devDependencies": {
     "@angular/cli": "~11.0.0",
-    "@schematics/angular": "~11.0.0",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "^12.11.1",

--- a/src/generate/utils.ts
+++ b/src/generate/utils.ts
@@ -1,5 +1,6 @@
-import { getPackageJson } from '../utils'; //getNsConfig
+import { getPackageJson } from '../utils';
 import { Tree, SchematicsException } from '@angular-devkit/schematics';
+import { normalize } from '@angular-devkit/core';
 import { extname } from 'path';
 import { Schema as ComponentOptions } from './component/schema';
 import { Schema as ModuleOptions } from './module/schema';
@@ -31,15 +32,7 @@ const isNs = (tree: Tree) => {
 };
 
 const isWeb = (tree: Tree) => {
-  if (!tree.exists('nativescript.config.ts')) {
-    console.log(`nativescript.config.ts not found. Assuming this is a {N} only project`);
-
-    return false;
-  }
-
-  // const config = getNsConfig(tree);
-
-  return true;//config.webext != null;
+  return tree.exists(normalize('/src/main.tns.ts'));
 };
 
 export interface PlatformUse {
@@ -77,24 +70,16 @@ export const getPlatformUse = (tree: Tree, options: Options): PlatformUse => {
 };
 
 export const getExtensions = (tree: Tree, options: Options): Extensions => {
-  // let ns = options.nsExtension;
-  // let web = options.webExtension;
-
-  // if (isWeb(tree)) {
-  //   const nsconfig = getNsConfig(tree);
-
-  //   ns = ns || nsconfig.nsext;
-  //   web = web || nsconfig.webext;
-
-  //   if (ns === web) {
-  //     ns = DEFAULT_SHARED_EXTENSIONS.ns;
-  //     web = DEFAULT_SHARED_EXTENSIONS.web;
-  //   }
-  // }
+  if (isWeb(tree)) {
+    return {
+      ns: DEFAULT_SHARED_EXTENSIONS.ns,
+      web: DEFAULT_SHARED_EXTENSIONS.web,
+    };
+  }
 
   return {
-    ns: DEFAULT_SHARED_EXTENSIONS.ns,// parseExtension(ns || ''),
-    web: DEFAULT_SHARED_EXTENSIONS.web //parseExtension(web || ''),
+    ns: '',
+    web: '',
   };
 };
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA].
- [x] All existing tests are passing (I have not broken more 😉): https://github.com/NativeScript/nativescript-schematics/blob/master/CONTRIBUTING.md#running-tests.
- [x] Tests for the changes are included (there's no new functionality).

## What is the current behavior?
1. `@schematics/angular` v11.1+ has introduced a breaking change where `@schematics/angular/utility/config` has been removed. `@angular/cli` v11.1+ seems automatically install these new versions. In v11.1+ version of `@schematics/angular`, getWorkespace method is instead at `@schematics/angular/utility/workespace` and is async now as pointed out at #311 by @avif. Using it requires a major codebase migration. Forcing this version (~11.0.0) via regular dependencies allows to continue using `@nativescript/schematics` with NG11.1 and NG11.2 projects, but further action should be taken before NG12 arrives.
2. There was a bug in the code generation utils by which every NS NG project counted as a shared project, thus generating web components in NS-only projects. The `isWeb()` utility function was considering the existence of a `nativescript.config.ts` file as a sign of a shared project configuration, when now every NS project has this file. Instead now this decision is driven by the existence of a main.tns.ts file inside the src folder.
3. There was a regression which lead to including the `.tns` extension in all NG NS components during their generation, independently of the kind of project (shared or NS only). This extension should be used in NS component files inside shared projects only.
4. Given all NS NG templates use sass preprocessor with scss extension, it should be stated in the docs how to configure angular.json file to make this the default style sheets extension during component generation.

## What is the new behavior?
1. @schematics/angular dev dependency has been temporally promoted to become a regular dependency thus forcing a specific version range which still works with @nativescript/schematics in NG11.1+ projects as expected with no extra setup steps (like manually adding this dependency to the package.json of the project)
2. The `isWeb()`utility function has been refactored to detect the existence of a `main.tns.ts` file instead.
3. When run inside a shared project `getExtensions()` utility function returns different extensions for NS and web components, otherwise  it returns blank extension prefixes for NS-only projects.
4. Docs have been updated to reflect this possibility.

Fixes/Implements/Closes #311, #309 and #307.

BREAKING CHANGES:
None, to the best of my knowledge.

Migration steps:
None, since by merging this changes it will be possible to use @nativescript/schematics with NG11.1+ projects as expected by just following setup instructions (with no extra steps or workaround like manually installing `@schematics/angular@~11.0.0`).

----
> This is my first PR, I don't know if something else is needed (please, reach me out if so). I just wanted to help making this working back again for new projects
